### PR TITLE
Update HUAWEI VRP prompt pattern

### DIFF
--- a/docs/scrapli_community/huawei/vrp/huawei_vrp.html
+++ b/docs/scrapli_community/huawei/vrp/huawei_vrp.html
@@ -36,7 +36,7 @@ from scrapli_community.huawei.vrp.sync import default_sync_on_close, default_syn
 DEFAULT_PRIVILEGE_LEVELS = {
     &#34;privilege_exec&#34;: (
         PrivilegeLevel(
-            pattern=r&#34;^[&lt;a-z0-9.\-@()/:]{1,48}[#&gt;$]\s*$&#34;,
+            pattern=r&#34;^&lt;[a-z0-9.\-_@()/:]{1,48}&gt;\s*$&#34;,
             name=&#34;privilege_exec&#34;,
             previous_priv=&#34;&#34;,
             deescalate=&#34;&#34;,

--- a/docs/scrapli_community/huawei/vrp/huawei_vrp.html
+++ b/docs/scrapli_community/huawei/vrp/huawei_vrp.html
@@ -47,7 +47,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     &#34;configuration&#34;: (
         PrivilegeLevel(
-            pattern=r&#34;^\[[a-z0-9.\-@/:]{1,32}\]$&#34;,
+            pattern=r&#34;^\[[a-z0-9.\-_@/:]{1,64}\]$&#34;,
             name=&#34;configuration&#34;,
             previous_priv=&#34;privilege_exec&#34;,
             deescalate=&#34;quit&#34;,

--- a/scrapli_community/huawei/vrp/_async.py
+++ b/scrapli_community/huawei/vrp/_async.py
@@ -1,4 +1,4 @@
-"""scrapli_community.huawei.vrp._ansync"""
+"""scrapli_community.huawei.vrp._async"""
 from scrapli.driver import AsyncNetworkDriver
 
 

--- a/scrapli_community/huawei/vrp/huawei_vrp.py
+++ b/scrapli_community/huawei/vrp/huawei_vrp.py
@@ -18,7 +18,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^\[[a-z0-9.\-@/:]{1,32}\]$",
+            pattern=r"^\[[a-z0-9.\-_@/:]{1,64}\]$",
             name="configuration",
             previous_priv="privilege_exec",
             deescalate="quit",

--- a/scrapli_community/huawei/vrp/huawei_vrp.py
+++ b/scrapli_community/huawei/vrp/huawei_vrp.py
@@ -7,7 +7,7 @@ from scrapli_community.huawei.vrp.sync import default_sync_on_close, default_syn
 DEFAULT_PRIVILEGE_LEVELS = {
     "privilege_exec": (
         PrivilegeLevel(
-            pattern=r"^[<a-z0-9.\-@()/:]{1,48}[#>$]\s*$",
+            pattern=r"^<[a-z0-9.\-_@()/:]{1,48}>\s*$",
             name="privilege_exec",
             previous_priv="",
             deescalate="",

--- a/tests/unit/huawei/vrp/test_huawei_vrp.py
+++ b/tests/unit/huawei/vrp/test_huawei_vrp.py
@@ -1,0 +1,26 @@
+import re
+
+import pytest
+
+from scrapli_community.huawei.vrp.huawei_vrp import DEFAULT_PRIVILEGE_LEVELS
+
+
+@pytest.mark.parametrize(
+    "priv_pattern",
+    [
+        ("privilege_exec", "<SCRAPLI_HUAWEI-VRP_TEST_SW1>"),
+        ("configuration", "[SCRAPLI_HUAWEI-VRP_TEST_SW1]"),
+        ("configuration", "[SCRAPLI_HUAWEI-VRP_TEST_SW1-GigabitEthernet0/0/1]"),
+    ],
+    ids=[
+        "ssh_prompt_privilege_exec",
+        "ssh_prompt_configuration",
+        "ssh_prompt_configuration_interface",
+    ],
+)
+def test_default_prompt_patterns(priv_pattern):
+    priv_level_name = priv_pattern[0]
+    prompt = priv_pattern[1]
+    prompt_pattern = DEFAULT_PRIVILEGE_LEVELS.get(priv_level_name).pattern
+    match = re.search(pattern=prompt_pattern, string=prompt, flags=re.M | re.I)
+    assert match


### PR DESCRIPTION
# Description

Updated the HUAWEI VRP prompt pattern to allow for hostnames containing underscores (for example "SCRAPLI_HUAWEI-VRP_TEST_SW1"). 

Also added some basic tests to verify the pattern.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Tested this PR by adding some basic pattern testing and testing the changes against ~270 routers & switches running various versions of HUAWEI VRP with various hostname patterns.


# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions compalints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
