### PR TITLE
Updated HUAWEI VRP configuration prompt pattern.

### DIFF
--- a/scrapli_community/huawei/vrp/huawei_vrp.py
+++ b/scrapli_community/huawei/vrp/huawei_vrp.py
@@ -18,7 +18,25 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^\[[a-z0-9.\-_@/:]{1,64}\]$",
+            # On some versions of VRP running on the AR160 & AR650 router series (and possibly
+            # others), the router outputs the current OS version in the following format when
+            # calling the command 'display current-configuration':
+            #
+            # <HOSTNAME>display current-configuration
+            # [V200R009C00SPC500]
+            # #
+            # sysname HOSTNAME
+            # ...
+            #
+            # Since the version string is basically in the same format as the prompt in
+            # configuration mode, scrapli only reads until it sees this very string, and then
+            # stops reading since it assumes that a valid prompt has been found.
+            #
+            # The following pattern tries to prevent this from happening by using a regex negative
+            # lookahead to exclude '[V***R***C**]' from the prompt pattern, but still match
+            # a regular hostname.
+            #
+            pattern=r"^(?!\[V\d{3}R\d{3}C\d{2,3}.*\])(?=\[[a-z0-9.\-_@/:]{1,64}\]$).*$",
             name="configuration",
             previous_priv="privilege_exec",
             deescalate="quit",
@@ -30,7 +48,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
 }
 
 SCRAPLI_PLATFORM = {
-    "driver_type": "network",  # generic|network
+    "driver_type": "network",
     "defaults": {
         "privilege_levels": DEFAULT_PRIVILEGE_LEVELS,
         "default_desired_privilege_level": "privilege_exec",
@@ -38,7 +56,11 @@ SCRAPLI_PLATFORM = {
         "async_on_open": default_async_on_open,
         "sync_on_close": default_sync_on_close,
         "async_on_close": default_async_on_close,
-        "failed_when_contains": [],
+        "failed_when_contains": [
+            "Error: Unrecognized command found at '^' position.",
+            "Error: Wrong parameter found at '^' position.",
+            "Error:Incomplete command found at '^' position.",
+        ],
         "textfsm_platform": "huawei_vrp",
         "genie_platform": "",
     },

--- a/tests/unit/huawei/vrp/test_huawei_vrp.py
+++ b/tests/unit/huawei/vrp/test_huawei_vrp.py
@@ -21,6 +21,29 @@ from scrapli_community.huawei.vrp.huawei_vrp import DEFAULT_PRIVILEGE_LEVELS
 def test_default_prompt_patterns(priv_pattern):
     priv_level_name = priv_pattern[0]
     prompt = priv_pattern[1]
+
     prompt_pattern = DEFAULT_PRIVILEGE_LEVELS.get(priv_level_name).pattern
     match = re.search(pattern=prompt_pattern, string=prompt, flags=re.M | re.I)
+
     assert match
+
+
+@pytest.mark.parametrize(
+    "priv_pattern",
+    [
+        ("configuration", "[V200R009C00SPC500]"),
+        ("configuration", "[V300R009C10HP0006]"),
+    ],
+    ids=[
+        "ssh_prompt_configuration",
+        "ssh_prompt_configuration",
+    ],
+)
+def test_prompt_patterns_ignore_version_string(priv_pattern):
+    priv_level_name = priv_pattern[0]
+    prompt = priv_pattern[1]
+
+    prompt_pattern = DEFAULT_PRIVILEGE_LEVELS.get(priv_level_name).pattern
+    match = re.search(pattern=prompt_pattern, string=prompt, flags=re.M | re.I)
+
+    assert not match


### PR DESCRIPTION
# Description

On some versions of HUAWEI VRP, the output of the command `display current-configuration` includes the current OS version in the following format:

```
<HOSTNAME>display current-configuration
[V200R009C00SPC500]
#
sysname HOSTNAME
...
```

Since this version string matches the pattern used to detect the prompt in configuration mode, scrapli stops reading the output from this specific command, since it assumes that a valid prompt has been found.

The updated pattern tries to prevent this from happening by using a regex negative lookahead to exclude the version string from the allowed prompt patterns.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested this change on the devices where scrapli didn't read the entire output from the `display current-configuration` command, and confirmed that the output is now read until the end.

Also added some new test cases to check that the pattern excludes such versions strings.

# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions compalints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
