### PR TITLE
vrp refactor

### DIFF
--- a/scrapli_community/huawei/vrp/_async.py
+++ b/scrapli_community/huawei/vrp/_async.py
@@ -1,4 +1,6 @@
 """scrapli_community.huawei.vrp._async"""
+from typing import Any
+
 from scrapli.driver import AsyncNetworkDriver
 
 
@@ -37,3 +39,14 @@ async def default_async_on_close(conn: AsyncNetworkDriver) -> None:
     await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     conn.transport.write(channel_input="exit")
     conn.transport.write(channel_input=conn.channel.comms_return_char)
+
+
+class AsyncHuaweiVRPDriver(AsyncNetworkDriver):
+    def __init__(self, **kwargs: Any) -> None:
+        # *if* using anything but system transport pop out ptyprocess transport options, leaving
+        # anything else
+        transport_plugin = kwargs.get("transport", "system")
+        if transport_plugin != "system":
+            kwargs.get("transport_options", {}).pop("ptyprocess")
+
+        super().__init__(**kwargs)

--- a/scrapli_community/huawei/vrp/_async.py
+++ b/scrapli_community/huawei/vrp/_async.py
@@ -43,6 +43,19 @@ async def default_async_on_close(conn: AsyncNetworkDriver) -> None:
 
 class AsyncHuaweiVRPDriver(AsyncNetworkDriver):
     def __init__(self, **kwargs: Any) -> None:
+        """
+        Huawei VRP platform class
+
+        Args:
+            kwargs: keyword args
+
+        Returns:
+            N/A  # noqa: DAR202
+
+        Raises:
+            N/A
+
+        """
         # *if* using anything but system transport pop out ptyprocess transport options, leaving
         # anything else
         transport_plugin = kwargs.get("transport", "system")

--- a/scrapli_community/huawei/vrp/huawei_vrp.py
+++ b/scrapli_community/huawei/vrp/huawei_vrp.py
@@ -1,8 +1,16 @@
 """scrapli_community.huawei.vrp.huawei_vrp"""
 from scrapli.driver.base_network_driver import PrivilegeLevel
 
-from scrapli_community.huawei.vrp._async import default_async_on_close, default_async_on_open
-from scrapli_community.huawei.vrp.sync import default_sync_on_close, default_sync_on_open
+from scrapli_community.huawei.vrp._async import (
+    AsyncHuaweiVRPDriver,
+    default_async_on_close,
+    default_async_on_open,
+)
+from scrapli_community.huawei.vrp.sync import (
+    HuaweiVRPDriver,
+    default_sync_on_close,
+    default_sync_on_open,
+)
 
 DEFAULT_PRIVILEGE_LEVELS = {
     "privilege_exec": (
@@ -48,7 +56,10 @@ DEFAULT_PRIVILEGE_LEVELS = {
 }
 
 SCRAPLI_PLATFORM = {
-    "driver_type": "network",
+    "driver_type": {
+        "sync": HuaweiVRPDriver,
+        "async": AsyncHuaweiVRPDriver,
+    },
     "defaults": {
         "privilege_levels": DEFAULT_PRIVILEGE_LEVELS,
         "default_desired_privilege_level": "privilege_exec",

--- a/scrapli_community/huawei/vrp/sync.py
+++ b/scrapli_community/huawei/vrp/sync.py
@@ -43,6 +43,19 @@ def default_sync_on_close(conn: NetworkDriver) -> None:
 
 class HuaweiVRPDriver(NetworkDriver):
     def __init__(self, **kwargs: Any) -> None:
+        """
+        Huawei VRP platform class
+
+        Args:
+            kwargs: keyword args
+
+        Returns:
+            N/A  # noqa: DAR202
+
+        Raises:
+            N/A
+
+        """
         # *if* using anything but system transport pop out ptyprocess transport options, leaving
         # anything else
         transport_plugin = kwargs.get("transport", "system")

--- a/scrapli_community/huawei/vrp/sync.py
+++ b/scrapli_community/huawei/vrp/sync.py
@@ -1,4 +1,6 @@
 """scrapli_community.huawei.vrp.sync"""
+from typing import Any
+
 from scrapli.driver import NetworkDriver
 
 
@@ -37,3 +39,14 @@ def default_sync_on_close(conn: NetworkDriver) -> None:
     conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     conn.transport.write(channel_input="exit")
     conn.transport.write(channel_input=conn.channel.comms_return_char)
+
+
+class HuaweiVRPDriver(NetworkDriver):
+    def __init__(self, **kwargs: Any) -> None:
+        # *if* using anything but system transport pop out ptyprocess transport options, leaving
+        # anything else
+        transport_plugin = kwargs.get("transport", "system")
+        if transport_plugin != "system":
+            kwargs.get("transport_options", {}).pop("ptyprocess")
+
+        super().__init__(**kwargs)

--- a/scrapli_community/mikrotik/routeros/_async.py
+++ b/scrapli_community/mikrotik/routeros/_async.py
@@ -30,7 +30,6 @@ class AsyncMikrotikRouterOSDriver(AsyncGenericDriver):
         Mikrotik RouterOS platform class
 
         Args:
-            args: positional args
             kwargs: keyword args
 
         Returns:

--- a/scrapli_community/mikrotik/routeros/_async.py
+++ b/scrapli_community/mikrotik/routeros/_async.py
@@ -25,7 +25,7 @@ async def default_async_on_close(conn: AsyncGenericDriver) -> None:
 
 
 class AsyncMikrotikRouterOSDriver(AsyncGenericDriver):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         """
         Mikrotik RouterOS platform class
 
@@ -45,7 +45,7 @@ class AsyncMikrotikRouterOSDriver(AsyncGenericDriver):
         # https://wiki.mikrotik.com/wiki/Manual:Console_login_process
         kwargs["auth_username"] += "+cet511w4098h"
 
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
     async def send_command(
         self,

--- a/scrapli_community/mikrotik/routeros/mikrotik_routeros.py
+++ b/scrapli_community/mikrotik/routeros/mikrotik_routeros.py
@@ -1,5 +1,4 @@
 """scrapli_community.mikrotik.routeros.mikrotik_routeros"""
-
 from scrapli_community.mikrotik.routeros._async import (
     AsyncMikrotikRouterOSDriver,
     default_async_on_close,

--- a/scrapli_community/mikrotik/routeros/sync.py
+++ b/scrapli_community/mikrotik/routeros/sync.py
@@ -25,7 +25,7 @@ def default_sync_on_close(conn: GenericDriver) -> None:
 
 
 class MikrotikRouterOSDriver(GenericDriver):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         """
         Mikrotik RouterOS platform class
 
@@ -45,7 +45,7 @@ class MikrotikRouterOSDriver(GenericDriver):
         # https://wiki.mikrotik.com/wiki/Manual:Console_login_process
         kwargs["auth_username"] += "+cet511w4098h"
 
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
     def send_command(
         self,

--- a/scrapli_community/mikrotik/routeros/sync.py
+++ b/scrapli_community/mikrotik/routeros/sync.py
@@ -30,7 +30,6 @@ class MikrotikRouterOSDriver(GenericDriver):
         Mikrotik RouterOS platform class
 
         Args:
-            args: positional args
             kwargs: keyword args
 
         Returns:


### PR DESCRIPTION
# Description

Refactor huawei vrp to be a "class setup" per convo in #26 

Also stopped passing args in huawei and also Mikrotik as the factory stuff will always pass kwargs!


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x] This change requires a documentation update

# How Has This Been Tested?

No real change to testing, checked that w/ non-system transport the transport option ptyprocess bits get dropped 

# Checklist:

- [x ] My code follows the style guidelines of this project (no GitHub actions compalints! run `make lint` before
 committing!)
- [ x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x ] New and existing unit tests pass locally with my changes
