### PR TITLE
Update mikrotik_routeros.py and fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The following are the currently supported platforms:
 | edgecore_ecs          | Edgecore        | ECS           | [Alex Lardschneider](https://github.com/AlexLardschneider) | 2020.09.19  | For the firmware shipped by Edgecore itself                                           |
 | fortinet_wlc          | Fortinet        | WLC           | [Alex Lardschneider](https://github.com/AlexLardschneider) | 2020.11.15  | For the Meru-based OS, not the same as FortiOS                                        |
 | aethra_atosnt         | Aethra          | ATOSNT        | [Alex Lardschneider](https://github.com/AlexLardschneider) | 2020.11.15  | Tested on ATOS NT, ranging from 6.3.X up to 6.5.X:                                    |
-| aethra_atosnt         | Mikrotik        | RouterOS      | [Alex Lardschneider](https://github.com/AlexLardschneider) | 2020.11.15  |                                                                                       |
+| mikrotik_routeros     | Mikrotik        | RouterOS      | [Alex Lardschneider](https://github.com/AlexLardschneider) | 2020.11.15  |                                                                                       |
 | siemens_roxii         | Siemens         | ROX II        | [Khiem Nguyen](https://github.com/kn-winter)               | 2021.01.30  |                                                                                       |
 
 

--- a/scrapli_community/mikrotik/routeros/mikrotik_routeros.py
+++ b/scrapli_community/mikrotik/routeros/mikrotik_routeros.py
@@ -11,7 +11,7 @@ SCRAPLI_PLATFORM = {
         "async": AsyncMikrotikRouterOSDriver,
     },
     "defaults": {
-        "comms_prompt_pattern": r"\[[a-z0-9.\-_+\s]{1,48}@[a-z0-9.\-_\s]{1,64}\].{1,16}>",
+        "comms_prompt_pattern": r"\[[a-z0-9@.\-_+\s]{1,48}@[a-z0-9.\-_\s]{1,64}\].{1,16}>",
         "comms_return_char": "\r\n",  # Mikrotik ROS uses '\r\n' as newline character.
         "sync_on_open": None,
         "async_on_open": None,


### PR DESCRIPTION
Fix case when username contains "@" sign (i.e user@domain), and prompt looks like 
[user@domain@mkt-01] >
