### PR TITLE
Avoid KeyError exception while removing item from dictionary

### DIFF
--- a/scrapli_community/hp/comware/_async.py
+++ b/scrapli_community/hp/comware/_async.py
@@ -60,6 +60,6 @@ class AsyncHPComwareDriver(AsyncNetworkDriver):
         # anything else
         transport_plugin = kwargs.get("transport", "system")
         if transport_plugin != "system":
-            kwargs.get("transport_options", {}).pop("ptyprocess")
+            kwargs.get("transport_options", {}).pop("ptyprocess", None)
 
         super().__init__(**kwargs)

--- a/scrapli_community/hp/comware/sync.py
+++ b/scrapli_community/hp/comware/sync.py
@@ -59,6 +59,6 @@ class HPComwareDriver(NetworkDriver):
         # anything else
         transport_plugin = kwargs.get("transport", "system")
         if transport_plugin != "system":
-            kwargs.get("transport_options", {}).pop("ptyprocess")
+            kwargs.get("transport_options", {}).pop("ptyprocess", None)
 
         super().__init__(**kwargs)

--- a/scrapli_community/huawei/vrp/_async.py
+++ b/scrapli_community/huawei/vrp/_async.py
@@ -60,6 +60,6 @@ class AsyncHuaweiVRPDriver(AsyncNetworkDriver):
         # anything else
         transport_plugin = kwargs.get("transport", "system")
         if transport_plugin != "system":
-            kwargs.get("transport_options", {}).pop("ptyprocess")
+            kwargs.get("transport_options", {}).pop("ptyprocess", None)
 
         super().__init__(**kwargs)

--- a/scrapli_community/huawei/vrp/sync.py
+++ b/scrapli_community/huawei/vrp/sync.py
@@ -59,6 +59,6 @@ class HuaweiVRPDriver(NetworkDriver):
         # anything else
         transport_plugin = kwargs.get("transport", "system")
         if transport_plugin != "system":
-            kwargs.get("transport_options", {}).pop("ptyprocess")
+            kwargs.get("transport_options", {}).pop("ptyprocess", None)
 
         super().__init__(**kwargs)


### PR DESCRIPTION
# Description

This PR adds workaround to safely `.pop()` item from config dictionary and don't trigger `KeyError` if the key is not present in the dictionary. Affected docs was regenerated as well.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

It's minor change, and I considered passing `make test` sufficient.

# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions compalints! run `make lint` before
 committing!)
 - `make lint` fails but on changes not related to this PR
- [x] New and existing unit tests pass locally with my changes
