### PR TITLE
Add Alcatel-Lucent Enterprise driver (aos6 & aos8) - readme excluded

### DIFF
--- a/scrapli_community/alcatel/__init__.py
+++ b/scrapli_community/alcatel/__init__.py
@@ -1,0 +1,1 @@
+"""scrapli_community.alcatel"""

--- a/scrapli_community/alcatel/aos/__init__.py
+++ b/scrapli_community/alcatel/aos/__init__.py
@@ -1,0 +1,4 @@
+"""scrapli_community.alcatel.aos"""
+from scrapli_community.alcatel.aos.alcatel_aos import SCRAPLI_PLATFORM
+
+__all__ = ("SCRAPLI_PLATFORM",)

--- a/scrapli_community/alcatel/aos/_async.py
+++ b/scrapli_community/alcatel/aos/_async.py
@@ -1,0 +1,20 @@
+"""scrapli_community.alcatel.aos._async"""
+from scrapli.driver import AsyncGenericDriver
+
+
+async def default_async_on_close(conn: AsyncGenericDriver) -> None:
+    """
+    Async alcatel_aos default on_close callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    conn.channel.write(channel_input="exit")
+    conn.channel.send_return()

--- a/scrapli_community/alcatel/aos/alcatel_aos.py
+++ b/scrapli_community/alcatel/aos/alcatel_aos.py
@@ -12,6 +12,5 @@ SCRAPLI_PLATFORM = {
         "async_on_open": None,
         "sync_on_close": default_sync_on_close,
         "async_on_close": default_async_on_close,
-        "transport": "ssh2",
     },
 }

--- a/scrapli_community/alcatel/aos/alcatel_aos.py
+++ b/scrapli_community/alcatel/aos/alcatel_aos.py
@@ -1,0 +1,17 @@
+"""scrapli_community.alcatel.aos.alcatel_aos"""
+
+from scrapli_community.alcatel.aos._async import default_async_on_close
+from scrapli_community.alcatel.aos.sync import default_sync_on_close
+
+SCRAPLI_PLATFORM = {
+    "driver_type": "generic",
+    "defaults": {
+        # Prompt can be anything, but best practice is to end with > or #
+        "comms_prompt_pattern": r"^[a-zA-Z0-9.\-_@\/:]{1,63}[>|#]\s*",
+        "sync_on_open": None,
+        "async_on_open": None,
+        "sync_on_close": default_sync_on_close,
+        "async_on_close": default_async_on_close,
+        "transport": "ssh2",
+    },
+}

--- a/scrapli_community/alcatel/aos/sync.py
+++ b/scrapli_community/alcatel/aos/sync.py
@@ -1,0 +1,20 @@
+"""scrapli_community.alcatel.aos.sync"""
+from scrapli.driver import GenericDriver
+
+
+def default_sync_on_close(conn: GenericDriver) -> None:
+    """
+    alcatel_aos default on_close callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    conn.channel.write(channel_input="exit")
+    conn.channel.send_return()


### PR DESCRIPTION
# Description

Adds driver for Alcatel-Lucent Enterprise aos6 and aos8 devices.

# Tested against:
- aos6: 6.7.2.89.R06
- aos8: 8.6.289.R01

## Type of change

- [ x ] New feature (non-breaking change which adds functionality)
- [ x ] This change requires a documentation update