### PR TITLE
Fixed classic CLI REGEXP and failed_when_contains

### DIFF
--- a/scrapli_community/nokia/sros/nokia_sros.py
+++ b/scrapli_community/nokia/sros/nokia_sros.py
@@ -61,7 +61,7 @@ CLASSIC_DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^\*?[abcd]:[\w]+>config#\s?$",
+            pattern=r"\*?[abcd]:[\w\s-]+>config[\w>]*(#|\$)\s?$",
             name="configuration",
             previous_priv="exec",
             deescalate="exit all",
@@ -95,7 +95,10 @@ SCRAPLI_PLATFORM = {
             "sync_on_open": classic_default_sync_on_open,
             "async_on_open": classic_default_async_on_open,
             "failed_when_contains": [
+                "MINOR:",
+                "MAJOR:",
                 "Error:",
+                "Bad Command:",
             ],
         },
     },


### PR DESCRIPTION
# Description

Fixed classic CLI config prompt REGEXP and added error messages detection.


## Type of change
- [ X ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested on the following Nokia SAS platforms:
- SAS-K => TiMOS-B-9.0.R10 
- SAS-D  => TiMOS-B-9.0.R10 
- SAS-T => TiMOS-B-21.3.R1
