### PR TITLE
SROS MD-CLI RE fix and additional characters support

### DIFF
--- a/scrapli_community/nokia/sros/nokia_sros.py
+++ b/scrapli_community/nokia/sros/nokia_sros.py
@@ -14,7 +14,7 @@ from scrapli_community.nokia.sros.sync_driver import (
 DEFAULT_PRIVILEGE_LEVELS = {
     "exec": (
         PrivilegeLevel(
-            pattern=r"^(?!\(ex\)|\(ro\)|\(gl\)|\(pr\))\[.*\]\n[abcd]:[\w]+@[\w]+#\s?$",
+            pattern=r"^(?!\(ex\)|\(ro\)|\(gl\)|\(pr\))\[.*\]\n[abcd]:[\w\._]+@[\w\s_-]+#\s?$",
             name="exec",
             previous_priv="",
             deescalate="",
@@ -25,7 +25,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^(?:!|\*)?\(ex\)\[/?\]\n\*?[abcd]:[\w]+@[\w]+#\s?$",
+            pattern=r"^(?:!|\*)?\(ex\)\[\/?\]\n\*?[abcd]:[\w\._]+@[\w\s_-]+#\s?$",
             name="configuration",
             previous_priv="exec",
             deescalate="quit-config",
@@ -36,7 +36,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration_with_path": (
         PrivilegeLevel(
-            pattern=r"^(?:!|\*)?\(ex\)\[\S{2,}\]\n\*?[abcd]:[\w]+@[\w]+#\s?$",
+            pattern=r"^(?:!|\*)?\(ex\)\[(\S|\s){2,}\]\n\*?[abcd]:[\w\._]+@[\w\s_-]+#\s?$",
             name="configuration_with_path",
             previous_priv="exec",
             deescalate="exit all",
@@ -50,7 +50,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
 CLASSIC_DEFAULT_PRIVILEGE_LEVELS = {
     "exec": (
         PrivilegeLevel(
-            pattern=r"^\*?[abcd]:[\w]+#\s?$",
+            pattern=r"^\*?[abcd]:[\w\s_-]+#\s?$",
             name="exec",
             previous_priv="",
             deescalate="",
@@ -61,7 +61,7 @@ CLASSIC_DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^\*?[abcd]:[\w\s-]+>config[\w>]*(#|\$)\s?$",
+            pattern=r"^\*?[abcd]:[\w\s_-]+>config[\w>]*(#|\$)\s?$",
             name="configuration",
             previous_priv="exec",
             deescalate="exit all",


### PR DESCRIPTION
# Description

- Additional characters support for username (dot and underscore) and hostname (whitespace, underscore, dash)
- Fixed configuration_with_path Regexp

MD-CLI Exec RE:
https://regex101.com/r/Xn0SSQ/3

MD-CLI Configuration RE:
https://regex101.com/r/DFnT3v/1

MD-CLI Configuration with path RE:
https://regex101.com/r/YgDmTk/1

## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Not actually tested on MD-CLI SROS nodes. Regexp tested offline against real MD-CLI SROS prompt.
