### PR TITLE
add Cisco CBS

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =======
 
+# 2021.XX.XX
+- Add Cisco CBS -- see #76
+
 
 # 2021.07.30
 - Add HP Comware (thank you to Julien!) -- see #36

--- a/docs/user_guide/project_details.md
+++ b/docs/user_guide/project_details.md
@@ -28,6 +28,7 @@ The following are the currently supported platforms:
 | nokia_sros            | Nokia           | SROS          | [Roman Dodin](https://github.com/hellt)                    | 2021.07.30  |                                                                                       |
 | alcatel_aos           | Alcatel-Lucent  | AOS6 & AOS8   | [Jef Vantongerloo](https://github.com/jefvantongerloo)     | 2021.07.30  | Tested on aos6 - 6.7.2.89.R06 and aos8 - 8.6.289.R01                                  |
 | paloalto_panos        | PaloAlto        | PanOS         | [Bryan Bartik](https://github.com/jefvantongerloo)         | 2021.07.30  | Tested on PanOS 9.x and 10.x                                                          |
+| cisco_cbs             | Cisco           | CBS           | [Andrey Grechin](https://github.com/andreygrechin)         | 2021.XX.XX  | Tested on SG250-08, 2.5.7.85                                                          |
 
 
 ## Why add a Platform

--- a/scrapli_community/cisco/__init__.py
+++ b/scrapli_community/cisco/__init__.py
@@ -1,0 +1,1 @@
+"""scrapli_community.cisco"""

--- a/scrapli_community/cisco/cbs/__init__.py
+++ b/scrapli_community/cisco/cbs/__init__.py
@@ -1,0 +1,4 @@
+"""scrapli_community.cisco.cbs"""
+from scrapli_community.cisco.cbs.cisco_cbs import SCRAPLI_PLATFORM
+
+__all__ = ("SCRAPLI_PLATFORM",)

--- a/scrapli_community/cisco/cbs/async_driver.py
+++ b/scrapli_community/cisco/cbs/async_driver.py
@@ -1,0 +1,39 @@
+"""scrapli_community.cisco.cbs.async_driver"""
+from scrapli.driver import AsyncNetworkDriver
+
+
+async def default_async_on_open(conn: AsyncNetworkDriver) -> None:
+    """
+    cisco_cbs on_open callable
+
+    Args:
+        conn: AsyncNetworkDriver object
+
+    Returns:
+        None
+
+    Raises:
+        N/A
+    """
+    await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    await conn.send_command(command="terminal datadump")
+    await conn.send_command(command="terminal width 0")
+
+
+async def default_async_on_close(conn: AsyncNetworkDriver) -> None:
+    """
+    cisco_cbs default on_close callable
+
+    Args:
+        conn: AsyncNetworkDriver object
+
+    Returns:
+        None
+
+    Raises:
+        N/A
+
+    """
+    await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.channel.write(channel_input="exit")
+    conn.channel.send_return()

--- a/scrapli_community/cisco/cbs/cisco_cbs.py
+++ b/scrapli_community/cisco/cbs/cisco_cbs.py
@@ -1,0 +1,61 @@
+"""scrapli_community.cisco.cbs.cisco_cbs"""
+from scrapli.driver.network.base_driver import PrivilegeLevel
+from scrapli_community.cisco.cbs.async_driver import default_async_on_close, default_async_on_open
+from scrapli_community.cisco.cbs.sync_driver import default_sync_on_close, default_sync_on_open
+
+DEFAULT_PRIVILEGE_LEVELS = {
+    "exec": (
+        PrivilegeLevel(
+            pattern=r"^[a-zA-Z0-9-.]{1,58}>$",
+            name="exec",
+            previous_priv="",
+            deescalate="",
+            escalate="",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+    "privilege_exec": (
+        PrivilegeLevel(
+            pattern=r"^[a-zA-Z0-9-.]{1,58}#$",
+            name="privilege_exec",
+            previous_priv="exec",
+            deescalate="disable",
+            escalate="enable",
+            escalate_auth=True,
+            escalate_prompt=r"^(?:enable\s){0,1}Password:\s?$",
+        )
+    ),
+    "configuration": (
+        PrivilegeLevel(
+            pattern=r"^[a-zA-Z0-9-.]{1,58}\([\w.\-@/:+]{1,32}\)#$",
+            name="configuration",
+            previous_priv="privilege_exec",
+            deescalate="end",
+            escalate="configure terminal",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+}
+
+SCRAPLI_PLATFORM = {
+    "driver_type": "network",
+    "defaults": {
+        "privilege_levels": DEFAULT_PRIVILEGE_LEVELS,
+        "default_desired_privilege_level": "privilege_exec",
+        "sync_on_open": default_sync_on_open,
+        "async_on_open": default_async_on_open,
+        "sync_on_close": default_sync_on_close,
+        "async_on_close": default_async_on_close,
+        "failed_when_contains": [
+            "% Incomplete command",
+            "% Unrecognized command",
+            "% missing mandatory parameter",
+            "% bad parameter value",
+            "% Ambiguous command",
+        ],
+        "textfsm_platform": "cisco_s300",
+        "genie_platform": "",
+    },
+}

--- a/scrapli_community/cisco/cbs/sync_driver.py
+++ b/scrapli_community/cisco/cbs/sync_driver.py
@@ -1,0 +1,39 @@
+"""scrapli_community.cisco.cbs.sync_driver"""
+from scrapli.driver import NetworkDriver
+
+
+def default_sync_on_open(conn: NetworkDriver) -> None:
+    """
+    cisco_cbs on_open callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        None
+
+    Raises:
+        N/A
+    """
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.send_command(command="terminal datadump")
+    conn.send_command(command="terminal width 0")
+
+
+def default_sync_on_close(conn: NetworkDriver) -> None:
+    """
+    cisco_cbs default on_close callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        None
+
+    Raises:
+        N/A
+
+    """
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.channel.write(channel_input="exit")
+    conn.channel.send_return()

--- a/tests/unit/cisco/cbs/test_cisco_cbs.py
+++ b/tests/unit/cisco/cbs/test_cisco_cbs.py
@@ -1,0 +1,36 @@
+import re
+
+import pytest
+
+from scrapli_community.cisco.cbs.cisco_cbs import DEFAULT_PRIVILEGE_LEVELS
+
+
+@pytest.mark.parametrize(
+    "priv_pattern",
+    [
+        ("exec", "SG250-08>"),
+        ("privilege_exec", "SG250-08#"),
+        ("privilege_exec", "a1234567890123456...#"),
+        ("configuration", "SG250-08(config)#"),
+        ("configuration", "SG250-08(config-if)#"),
+        ("configuration", "a1234567890123456...(config)#"),
+        ("configuration", "a1234567890123456...(config-if)#"),
+    ],
+    ids=[
+        "ssh_prompt_exec",
+        "ssh_prompt_privilege_exec",
+        "ssh_prompt_privilege_exec",
+        "ssh_prompt_configuration",
+        "ssh_prompt_configuration",
+        "ssh_prompt_configuration_interface",
+        "ssh_prompt_configuration_interface",
+    ],
+)
+def test_default_prompt_patterns(priv_pattern):
+    priv_level_name = priv_pattern[0]
+    prompt = priv_pattern[1]
+
+    prompt_pattern = DEFAULT_PRIVILEGE_LEVELS.get(priv_level_name).pattern
+    match = re.search(pattern=prompt_pattern, string=prompt, flags=re.M | re.I)
+
+    assert match


### PR DESCRIPTION
# Description
Hi, 

This PR adds Cisco small business switches. This family includes different models SF/SG/CBS/220/250/350/550 which are based on TextView CLI.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on live SG250-08 with version 2.5.7.85, ntc-templates 2.2.2.

# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions compalints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes