### PR TITLE
Make Eltex SCRAPLI_PLATFORM failed_when_contains parameter more flexible

### DIFF
--- a/scrapli_community/eltex/esr/eltex_esr.py
+++ b/scrapli_community/eltex/esr/eltex_esr.py
@@ -48,7 +48,7 @@ SCRAPLI_PLATFORM = {
         "async_on_open": default_async_on_open,
         "sync_on_close": default_sync_on_close,
         "async_on_close": default_async_on_close,
-        "failed_when_contains": ["Syntax error: Illegal command line"],
+        "failed_when_contains": ["Syntax error:"],
         "textfsm_platform": "",
         "genie_platform": "",
     },


### PR DESCRIPTION
# Description

Hi Carl! I've changed Eltex SCRAPLI_PLATFORM failed_when_contains parameter to be less specific

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update