### PR TITLE
Allow '-' In Classic Prompt

### DIFF
--- a/scrapli_community/nokia/sros/nokia_sros.py
+++ b/scrapli_community/nokia/sros/nokia_sros.py
@@ -50,7 +50,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
 CLASSIC_DEFAULT_PRIVILEGE_LEVELS = {
     "exec": (
         PrivilegeLevel(
-            pattern=r"^\*?[abcd]:[\w]+#\s?$",
+            pattern=r"^\*?[abcd]:[\w\-]+#\s?$",
             name="exec",
             previous_priv="",
             deescalate="",
@@ -61,7 +61,7 @@ CLASSIC_DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^\*?[abcd]:[\w]+>config#\s?$",
+            pattern=r"^\*?[abcd]:[\w\-]+>config#\s?$",
             name="configuration",
             previous_priv="exec",
             deescalate="exit all",


### PR DESCRIPTION
# Description

The regex didn't allow hyphens in the classic prompt.  See discussion in https://github.com/scrapli/nornir_scrapli/discussions/73

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I used this on my physical router.

# Checklist:

- [ ] My code follows the style guidelines of this project (no GitHub actions compalints! run `make lint` before
 committing!)
- [ ] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [ ] New and existing unit tests pass locally with my changes
