### PR TITLE
DRAFT - Adding ASA and AireOS support

### DIFF
--- a/docs/user_guide/project_details.md
+++ b/docs/user_guide/project_details.md
@@ -50,6 +50,7 @@ So, again, why build a platform? Convenience and community mostly! Without a scr
 For example, (from the non core device example link above) without a scrapli community platform we may have to create
  our device connection like so:
 
+
 ```
 def wlc_on_open(cls):
     """Example `on_open` function for use with cisco wlc"""

--- a/docs/user_guide/project_details.md
+++ b/docs/user_guide/project_details.md
@@ -49,7 +49,7 @@ So, again, why build a platform? Convenience and community mostly! Without a scr
 
 For example, (from the non core device example link above) without a scrapli community platform we may have to create
  our device connection like so:
-
+make 
 
 ```
 def wlc_on_open(cls):

--- a/docs/user_guide/project_details.md
+++ b/docs/user_guide/project_details.md
@@ -49,7 +49,6 @@ So, again, why build a platform? Convenience and community mostly! Without a scr
 
 For example, (from the non core device example link above) without a scrapli community platform we may have to create
  our device connection like so:
-make 
 
 ```
 def wlc_on_open(cls):

--- a/docs/user_guide/project_details.md
+++ b/docs/user_guide/project_details.md
@@ -30,7 +30,9 @@ The following are the currently supported platforms:
 | paloalto_panos        | PaloAlto        | PanOS         | [Bryan Bartik](https://github.com/jefvantongerloo)         | 2021.07.30  | Tested on PanOS 9.x and 10.x                                                          |
 | cisco_cbs             | Cisco           | CBS           | [Andrey Grechin](https://github.com/andreygrechin)         | 2021.XX.XX  | Tested on SG250-08, 2.5.7.85                                                          |
 | aruba_aoscx             | Aruba           | AOSCX           | [Luke Bates](https://github.com/lukebates123)         | 2021.XX.XX  | Tested on ArubaOS-CX 10.05.x - 10.08.x                                                          |
-
+| cisco_asa             | Cisco           | ASA           | [Daniel Teycheney](https://github.com/writememe)         | 2021.XX.XX  | Tested on ASA 9.12.x                                                           |
+| cisco_aireos             | Cisco           | AireOS           | [Daniel Teycheney](https://github.com/writememe)         | 2021.XX.XX  | Tested on AireOS 8.5.x
+                                                           |
 ## Why add a Platform
 
 Why add a platform!? Because you think scrapli is awesome and want to be able to use it with whatever platform

--- a/scrapli_community/cisco/aireos/__init__.py
+++ b/scrapli_community/cisco/aireos/__init__.py
@@ -1,0 +1,4 @@
+"""scrapli_community.cisco.aireos"""
+from scrapli_community.cisco.aireos.cisco_aireos import SCRAPLI_PLATFORM
+
+__all__ = ("SCRAPLI_PLATFORM",)

--- a/scrapli_community/cisco/aireos/async_driver.py
+++ b/scrapli_community/cisco/aireos/async_driver.py
@@ -1,0 +1,39 @@
+"""scrapli_community.cisco.aireos.async_driver"""
+from scrapli.driver import AsyncNetworkDriver
+
+
+async def default_async_on_open(conn: AsyncNetworkDriver) -> None:
+    """
+    Async cisco_aireos default on_open callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    await conn.send_command(command="config paging disable")
+
+
+async def default_async_on_close(conn: AsyncNetworkDriver) -> None:
+    """
+    Async cisco_aireos default on_close callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.channel.write(channel_input="logout")
+    conn.channel.send_return()

--- a/scrapli_community/cisco/aireos/async_driver.py
+++ b/scrapli_community/cisco/aireos/async_driver.py
@@ -1,4 +1,6 @@
 """scrapli_community.cisco.aireos.async_driver"""
+import time
+
 from scrapli.driver import AsyncNetworkDriver
 
 
@@ -16,6 +18,18 @@ async def default_async_on_open(conn: AsyncNetworkDriver) -> None:
         N/A
 
     """
+    # Due to Cisco AireOS devices not having a true SSH authentication, the following
+    # technique has been employed to send the auth_username and auth_password to the device
+    # to handle the initial authentication.
+    # Reference Doco:
+    # https://carlmontanari.github.io/scrapli/user_guide/advanced_usage/#auth-bypass
+    # https://github.com/carlmontanari/scrapli/blob/master/examples/non_core_device/wlc.py#L25
+    time.sleep(0.25)
+    conn.channel.write(conn.auth_username)
+    conn.channel.send_return()
+    time.sleep(0.25)
+    conn.channel.write(conn.auth_password)
+    conn.channel.send_return()
     await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     await conn.send_command(command="config paging disable")
 

--- a/scrapli_community/cisco/aireos/cisco_aireos.py
+++ b/scrapli_community/cisco/aireos/cisco_aireos.py
@@ -47,5 +47,6 @@ SCRAPLI_PLATFORM = {
         ],
         "textfsm_platform": "cisco_wlc_ssh",
         "genie_platform": "",
+        "auth_bypass": True,
     },
 }

--- a/scrapli_community/cisco/aireos/cisco_aireos.py
+++ b/scrapli_community/cisco/aireos/cisco_aireos.py
@@ -1,0 +1,51 @@
+"""scrapli_community.cisco.aireos.cisco_aireos"""
+
+from scrapli.driver.network.base_driver import PrivilegeLevel
+from scrapli_community.cisco.aireos.async_driver import (
+    default_async_on_close,
+    default_async_on_open,
+)
+from scrapli_community.cisco.aireos.sync_driver import default_sync_on_close, default_sync_on_open
+
+DEFAULT_PRIVILEGE_LEVELS = {
+    "exec": (
+        PrivilegeLevel(
+            pattern=r"^\(Cisco Controller\) >$",
+            name="exec",
+            previous_priv="",
+            deescalate="",
+            escalate="",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+    "configuration": (
+        PrivilegeLevel(
+            pattern=r"^\(Cisco Controller\) config>$",
+            name="configuration",
+            previous_priv="exec",
+            deescalate="exit",
+            escalate="config",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+}
+
+SCRAPLI_PLATFORM = {
+    "driver_type": "network",
+    "defaults": {
+        "privilege_levels": DEFAULT_PRIVILEGE_LEVELS,
+        "default_desired_privilege_level": "exec",
+        "sync_on_open": default_sync_on_open,
+        "async_on_open": default_async_on_open,
+        "sync_on_close": default_sync_on_close,
+        "async_on_close": default_async_on_close,
+        "failed_when_contains": [
+            "Incorrect Usage. Use the '?' or <TAB> key to list commands.",
+            "Incorrect input!",
+        ],
+        "textfsm_platform": "cisco_wlc_ssh",
+        "genie_platform": "",
+    },
+}

--- a/scrapli_community/cisco/aireos/cisco_aireos.py
+++ b/scrapli_community/cisco/aireos/cisco_aireos.py
@@ -10,7 +10,7 @@ from scrapli_community.cisco.aireos.sync_driver import default_sync_on_close, de
 DEFAULT_PRIVILEGE_LEVELS = {
     "exec": (
         PrivilegeLevel(
-            pattern=r"^\(Cisco Controller\) >$",
+            pattern=r"^\([\w.\s]{1,31}\) >$",
             name="exec",
             previous_priv="",
             deescalate="",
@@ -21,7 +21,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^\(Cisco Controller\) config>$",
+            pattern=r"^\([\w.\s]{1,31}\) config>$",
             name="configuration",
             previous_priv="exec",
             deescalate="exit",

--- a/scrapli_community/cisco/aireos/sync_driver.py
+++ b/scrapli_community/cisco/aireos/sync_driver.py
@@ -1,0 +1,39 @@
+"""scrapli_community.cisco.aireos.sync_driver"""
+from scrapli.driver import NetworkDriver
+
+
+def default_sync_on_open(conn: NetworkDriver) -> None:
+    """
+    Async cisco_aireos default on_open callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.send_command(command="config paging disable")
+
+
+def default_sync_on_close(conn: NetworkDriver) -> None:
+    """
+    cisco_aireos default on_close callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.channel.write(channel_input="logout")
+    conn.channel.send_return()

--- a/scrapli_community/cisco/aireos/sync_driver.py
+++ b/scrapli_community/cisco/aireos/sync_driver.py
@@ -1,4 +1,6 @@
 """scrapli_community.cisco.aireos.sync_driver"""
+import time
+
 from scrapli.driver import NetworkDriver
 
 
@@ -16,6 +18,18 @@ def default_sync_on_open(conn: NetworkDriver) -> None:
         N/A
 
     """
+    # Due to Cisco AireOS devices not having a true SSH authentication, the following
+    # technique has been employed to send the auth_username and auth_password to the device
+    # to handle the initial authentication.
+    # Reference Doco:
+    # https://carlmontanari.github.io/scrapli/user_guide/advanced_usage/#auth-bypass
+    # https://github.com/carlmontanari/scrapli/blob/master/examples/non_core_device/wlc.py#L25
+    time.sleep(0.25)
+    conn.channel.write(conn.auth_username)
+    conn.channel.send_return()
+    time.sleep(0.25)
+    conn.channel.write(conn.auth_password)
+    conn.channel.send_return()
     conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     conn.send_command(command="config paging disable")
 

--- a/scrapli_community/cisco/asa/__init__.py
+++ b/scrapli_community/cisco/asa/__init__.py
@@ -1,0 +1,4 @@
+"""scrapli_community.cisco.aireos"""
+from scrapli_community.cisco.aireos.cisco_aireos import SCRAPLI_PLATFORM
+
+__all__ = ("SCRAPLI_PLATFORM",)

--- a/scrapli_community/cisco/asa/__init__.py
+++ b/scrapli_community/cisco/asa/__init__.py
@@ -1,4 +1,4 @@
 """scrapli_community.cisco.aireos"""
-from scrapli_community.cisco.aireos.cisco_aireos import SCRAPLI_PLATFORM
+from scrapli_community.cisco.asa.cisco_asa import SCRAPLI_PLATFORM
 
 __all__ = ("SCRAPLI_PLATFORM",)

--- a/scrapli_community/cisco/asa/async_driver.py
+++ b/scrapli_community/cisco/asa/async_driver.py
@@ -1,0 +1,39 @@
+"""scrapli_community.cisco.asa.async_driver"""
+from scrapli.driver import AsyncNetworkDriver
+
+
+async def default_async_on_open(conn: AsyncNetworkDriver) -> None:
+    """
+    Async cisco_asa default on_open callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    await conn.send_command(command="terminal pager 0")
+
+
+async def default_async_on_close(conn: AsyncNetworkDriver) -> None:
+    """
+    Async cisco_asa default on_close callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.channel.write(channel_input="logout")
+    conn.channel.send_return()

--- a/scrapli_community/cisco/asa/cisco_asa.py
+++ b/scrapli_community/cisco/asa/cisco_asa.py
@@ -7,7 +7,7 @@ from scrapli_community.cisco.asa.sync_driver import default_sync_on_close, defau
 DEFAULT_PRIVILEGE_LEVELS = {
     "exec": (
         PrivilegeLevel(
-            pattern=r"^[\S]{1,63}> $",
+            pattern=r"^[\S]{1,63}>(\s|)$",
             name="exec",
             previous_priv="",
             deescalate="",
@@ -18,7 +18,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "privilege_exec": (
         PrivilegeLevel(
-            pattern=r"^[\S]{1,63}# $",
+            pattern=r"^[\S]{1,63}#(\s|)$",
             name="privilege_exec",
             previous_priv="exec",
             deescalate="disable",
@@ -29,7 +29,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^[\w.\-@\:]{1,63}\([\w.\-@\:+]{0,32}\)# $",
+            pattern=r"^[\w.\-@\:]{1,63}\([\w.\-@\:+]{0,32}\)#(\s|)$",
             name="configuration",
             previous_priv="exec",
             deescalate="exit",
@@ -44,7 +44,7 @@ SCRAPLI_PLATFORM = {
     "driver_type": "network",
     "defaults": {
         "privilege_levels": DEFAULT_PRIVILEGE_LEVELS,
-        "default_desired_privilege_level": "exec",
+        "default_desired_privilege_level": "privilege_exec",
         "sync_on_open": default_sync_on_open,
         "async_on_open": default_async_on_open,
         "sync_on_close": default_sync_on_close,

--- a/scrapli_community/cisco/asa/cisco_asa.py
+++ b/scrapli_community/cisco/asa/cisco_asa.py
@@ -1,0 +1,60 @@
+"""scrapli_community.cisco.asa.cisco_asa"""
+
+from scrapli.driver.network.base_driver import PrivilegeLevel
+from scrapli_community.cisco.asa.async_driver import default_async_on_close, default_async_on_open
+from scrapli_community.cisco.asa.sync_driver import default_sync_on_close, default_sync_on_open
+
+DEFAULT_PRIVILEGE_LEVELS = {
+    "exec": (
+        PrivilegeLevel(
+            pattern=r"^[\S]{1,63}>$",
+            name="exec",
+            previous_priv="",
+            deescalate="",
+            escalate="",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+    "privilege_exec": (
+        PrivilegeLevel(
+            pattern=r"^[\S]{1,63}#$",
+            name="privilege_exec",
+            previous_priv="exec",
+            deescalate="disable",
+            escalate="enable",
+            escalate_auth=True,
+            escalate_prompt=r"^(P|p)assword:\s?$",
+        )
+    ),
+    "configuration": (
+        PrivilegeLevel(
+            pattern=r"^[\w.\-@\:]{1,63}\([\w.\-@\:+]{0,32}\)#$",
+            name="configuration",
+            previous_priv="exec",
+            deescalate="exit",
+            escalate="configure terminal",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+}
+
+SCRAPLI_PLATFORM = {
+    "driver_type": "network",
+    "defaults": {
+        "privilege_levels": DEFAULT_PRIVILEGE_LEVELS,
+        "default_desired_privilege_level": "exec",
+        "sync_on_open": default_sync_on_open,
+        "async_on_open": default_async_on_open,
+        "sync_on_close": default_sync_on_close,
+        "async_on_close": default_async_on_close,
+        "failed_when_contains": [
+            "% Invalid input detected",
+            "% Ambiguous command",
+            "% Incomplete command",
+        ],
+        "textfsm_platform": "cisco_asa",
+        "genie_platform": "asa",
+    },
+}

--- a/scrapli_community/cisco/asa/cisco_asa.py
+++ b/scrapli_community/cisco/asa/cisco_asa.py
@@ -7,7 +7,7 @@ from scrapli_community.cisco.asa.sync_driver import default_sync_on_close, defau
 DEFAULT_PRIVILEGE_LEVELS = {
     "exec": (
         PrivilegeLevel(
-            pattern=r"^[\S]{1,63}>(\s|)$",
+            pattern=r"^[\S]{1,63}>\s?$",
             name="exec",
             previous_priv="",
             deescalate="",
@@ -18,7 +18,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "privilege_exec": (
         PrivilegeLevel(
-            pattern=r"^[\S]{1,63}#(\s|)$",
+            pattern=r"^[\w.\-@\:]{1,63}#\s?$",
             name="privilege_exec",
             previous_priv="exec",
             deescalate="disable",
@@ -29,7 +29,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^[\w.\-@\:]{1,63}\([\w.\-@\:+]{0,32}\)#(\s|)$",
+            pattern=r"^[\w.\-@\:]{1,63}\([\w.\-@\:+]{0,32}\)#\s?$",
             name="configuration",
             previous_priv="exec",
             deescalate="exit",

--- a/scrapli_community/cisco/asa/cisco_asa.py
+++ b/scrapli_community/cisco/asa/cisco_asa.py
@@ -7,7 +7,7 @@ from scrapli_community.cisco.asa.sync_driver import default_sync_on_close, defau
 DEFAULT_PRIVILEGE_LEVELS = {
     "exec": (
         PrivilegeLevel(
-            pattern=r"^[\S]{1,63}>$",
+            pattern=r"^[\S]{1,63}> $",
             name="exec",
             previous_priv="",
             deescalate="",
@@ -18,7 +18,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "privilege_exec": (
         PrivilegeLevel(
-            pattern=r"^[\S]{1,63}#$",
+            pattern=r"^[\S]{1,63}# $",
             name="privilege_exec",
             previous_priv="exec",
             deescalate="disable",
@@ -29,7 +29,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^[\w.\-@\:]{1,63}\([\w.\-@\:+]{0,32}\)#$",
+            pattern=r"^[\w.\-@\:]{1,63}\([\w.\-@\:+]{0,32}\)# $",
             name="configuration",
             previous_priv="exec",
             deescalate="exit",

--- a/scrapli_community/cisco/asa/sync_driver.py
+++ b/scrapli_community/cisco/asa/sync_driver.py
@@ -1,0 +1,39 @@
+"""scrapli_community.cisco.asa.sync_driver"""
+from scrapli.driver import NetworkDriver
+
+
+def default_sync_on_open(conn: NetworkDriver) -> None:
+    """
+    Async cisco_asa default on_open callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.send_command(command="terminal pager 0")
+
+
+def default_sync_on_close(conn: NetworkDriver) -> None:
+    """
+    cisco_asa default on_close callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.channel.write(channel_input="logout")
+    conn.channel.send_return()

--- a/tests/unit/cisco/aireos/test_cisco_aireos.py
+++ b/tests/unit/cisco/aireos/test_cisco_aireos.py
@@ -5,8 +5,6 @@ import pytest
 from scrapli_community.cisco.aireos.cisco_aireos import DEFAULT_PRIVILEGE_LEVELS
 
 
-
-
 @pytest.mark.parametrize(
     "priv_pattern",
     [

--- a/tests/unit/cisco/aireos/test_cisco_aireos.py
+++ b/tests/unit/cisco/aireos/test_cisco_aireos.py
@@ -1,0 +1,25 @@
+import re
+
+import pytest
+
+from scrapli_community.cisco.aireos.cisco_aireos import DEFAULT_PRIVILEGE_LEVELS
+
+
+# TODO
+@pytest.mark.parametrize(
+    "priv_pattern",
+    [
+        ("exec", "(Cisco Controller) >"),
+        ("configuration", "(Cisco Controller) config>"),
+    ],
+    ids=[
+        "base_prompt_exec",
+        "base_prompt_configuration",
+    ],
+)
+def test_default_prompt_patterns(priv_pattern):
+    priv_level_name = priv_pattern[0]
+    prompt = priv_pattern[1]
+    prompt_pattern = DEFAULT_PRIVILEGE_LEVELS.get(priv_level_name).pattern
+    match = re.search(pattern=prompt_pattern, string=prompt, flags=re.M | re.I)
+    assert match

--- a/tests/unit/cisco/aireos/test_cisco_aireos.py
+++ b/tests/unit/cisco/aireos/test_cisco_aireos.py
@@ -5,16 +5,21 @@ import pytest
 from scrapli_community.cisco.aireos.cisco_aireos import DEFAULT_PRIVILEGE_LEVELS
 
 
-# TODO
+
+
 @pytest.mark.parametrize(
     "priv_pattern",
     [
         ("exec", "(Cisco Controller) >"),
+        ("exec", "(something_fun) >"),
         ("configuration", "(Cisco Controller) config>"),
+        ("configuration", "(Its interestin) config>"),
     ],
     ids=[
         "base_prompt_exec",
+        "base_prompt_exec_non_default",
         "base_prompt_configuration",
+        "base_prompt_configuration_non_default",
     ],
 )
 def test_default_prompt_patterns(priv_pattern):

--- a/tests/unit/cisco/asa/test_cisco_asa.py
+++ b/tests/unit/cisco/asa/test_cisco_asa.py
@@ -1,0 +1,37 @@
+import re
+
+import pytest
+
+from scrapli_community.cisco.asa.cisco_asa import DEFAULT_PRIVILEGE_LEVELS
+
+
+# TODO
+@pytest.mark.parametrize(
+    "priv_pattern",
+    [
+        ("exec", "ACME-FIREWALL>"),
+        ("exec", "ACME_FIREWALL>"),
+        ("exec", "ACME_FIREWALL/act/pri>"),
+        ("privilege_exec", "ACME-FIREWALL#"),
+        ("configuration", "ACME-FIREWALL(config)#"),
+        ("configuration", "ACME-FIREWALL(config-if)#"),
+        ("privilege_exec", "ACME_FIREWALL#"),
+        ("configuration", "ACME_FIREWALL(config)#"),
+    ],
+    ids=[
+        "base_prompt_exec",
+        "base_prompt_underscore_exec",
+        "base_prompt_underscore_exec_fw_status",
+        "base_prompt_privilege_exec",
+        "base_prompt_configuration",
+        "interface_configuration",
+        "base_prompt_underscore_privilege_exec",
+        "base_prompt_underscore_configuration",
+    ],
+)
+def test_default_prompt_patterns(priv_pattern):
+    priv_level_name = priv_pattern[0]
+    prompt = priv_pattern[1]
+    prompt_pattern = DEFAULT_PRIVILEGE_LEVELS.get(priv_level_name).pattern
+    match = re.search(pattern=prompt_pattern, string=prompt, flags=re.M | re.I)
+    assert match

--- a/tests/unit/cisco/asa/test_cisco_asa.py
+++ b/tests/unit/cisco/asa/test_cisco_asa.py
@@ -10,13 +10,13 @@ from scrapli_community.cisco.asa.cisco_asa import DEFAULT_PRIVILEGE_LEVELS
     "priv_pattern",
     [
         ("exec", "ACME-FIREWALL>"),
-        ("exec", "ACME_FIREWALL>"),
+        ("exec", "ACME_FIREWALL> "),
         ("exec", "ACME_FIREWALL/act/pri>"),
         ("privilege_exec", "ACME-FIREWALL#"),
         ("configuration", "ACME-FIREWALL(config)#"),
         ("configuration", "ACME-FIREWALL(config-if)#"),
-        ("privilege_exec", "ACME_FIREWALL#"),
-        ("configuration", "ACME_FIREWALL(config)#"),
+        ("privilege_exec", "ACME_FIREWALL# "),
+        ("configuration", "ACME_FIREWALL(config)# "),
     ],
     ids=[
         "base_prompt_exec",

--- a/tests/unit/cisco/asa/test_cisco_asa.py
+++ b/tests/unit/cisco/asa/test_cisco_asa.py
@@ -5,7 +5,6 @@ import pytest
 from scrapli_community.cisco.asa.cisco_asa import DEFAULT_PRIVILEGE_LEVELS
 
 
-# TODO
 @pytest.mark.parametrize(
     "priv_pattern",
     [


### PR DESCRIPTION
# Description

Adding Cisco ASA and Cisco AireOS support to scrapli community drivers.

NOTE: I've put the reasoning for my naming in #86 . As I said, happy to change the naming if you want.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
 list any relevant details for your test configuration


# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions compalints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes

## Test evidence

```python
(venv) ➜  scrapli_community git:(feature/asa-aireos) make lint
python -m isort .
Skipped 3 files
python -m black .
All done! ✨ 🍰 ✨
111 files left unchanged.
python -m pylama .
python -m pydocstyle .
python -m mypy --strict scrapli_community/
Success: no issues found in 92 source files
(venv) ➜  scrapli_community git:(feature/asa-aireos) make test
python -m pytest \
tests/
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.8.10, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /mnt/c/Users/dfjt/Documents/networking/projects/scrapli_community
plugins: pylama-7.7.1, cov-2.12.1
collected 84 items                                                                                                                                                                                        

tests/unit/aethra/atosnt/test_aethra_atosnt.py ...                                                                                                                                                  [  3%]
tests/unit/aruba/test_aruba_aoscx.py ...                                                                                                                                                            [  7%]
tests/unit/cisco/aireos/test_cisco_aireos.py ..                                                                                                                                                     [  9%]
tests/unit/cisco/asa/test_cisco_asa.py ........                                                                                                                                                     [ 19%]
tests/unit/cisco/cbs/test_cisco_cbs.py .......                                                                                                                                                      [ 27%]
tests/unit/edgecore/ecs/test_edgecore_ecs.py ...                                                                                                                                                    [ 30%]
tests/unit/eltex/esr/test_eltex_esr.py .......                                                                                                                                                      [ 39%]
tests/unit/fortinet/wlc/test_fortinet_wlc.py ...                                                                                                                                                    [ 42%]
tests/unit/huawei/vrp/test_huawei_vrp.py .....                                                                                                                                                      [ 48%]
tests/unit/mikrotik/routeros/test_mikrotik_routeros.py .......                                                                                                                                      [ 57%]
tests/unit/nokia/srlinux/test_nokia_srlinux.py ...                                                                                                                                                  [ 60%]
tests/unit/nokia/sros/test_nokia_sros.py ..........                                                                                                                                                 [ 72%]
tests/unit/paloalto/panos/test_paloalto_panos.py ......                                                                                                                                             [ 79%]
tests/unit/ruckus/fastiron/test_ruckus_fastiron.py ........                                                                                                                                         [ 89%]
tests/unit/scrapli/networkdriver/test_scrapli_networkdriver.py ......                                                                                                                               [ 96%]
tests/unit/siemens/roxii/test_siemens_roxii.py ...                                                                                                                                                  [100%]

=========================================================================================== 84 passed in 0.50s ============================================================================================
(venv) ➜  scrapli_community git:(feature/asa-aireos) 
```
