### PR TITLE
pattern upgrade for configuration mode for Huawei VRP8

### DIFF
--- a/scrapli_community/huawei/vrp/huawei_vrp.py
+++ b/scrapli_community/huawei/vrp/huawei_vrp.py
@@ -43,7 +43,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
             # lookahead to exclude '[V***R***C**]' from the prompt pattern, but still match
             # a regular hostname.
             #
-            pattern=r"^(?!\[V\d{3}R\d{3}C\d{2,3}.*\])(?=\[[a-z0-9.\-_@/:]{1,64}\]$).*$",
+            pattern=r"^(?!\[V\d{3}R\d{3}C\d{2,3}.*\])(?=\[\~{0,1}\*{0,1}[a-z0-9.\-_@/:]{1,64}\]$).*$",
             name="configuration",
             previous_priv="privilege_exec",
             deescalate="quit",

--- a/scrapli_community/huawei/vrp/huawei_vrp.py
+++ b/scrapli_community/huawei/vrp/huawei_vrp.py
@@ -43,7 +43,8 @@ DEFAULT_PRIVILEGE_LEVELS = {
             # lookahead to exclude '[V***R***C**]' from the prompt pattern, but still match
             # a regular hostname.
             #
-            pattern=r"^(?!\[V\d{3}R\d{3}C\d{2,3}.*\])(?=\[\~{0,1}\*{0,1}[a-z0-9.\-_@/:]{1,64}\]$).*$",
+            pattern=r"^(?!\[V\d{3}R\d{3}C\d{2,3}.*\])"
+            r"(?=\[\~{0,1}\*{0,1}[a-z0-9.\-_@/:]{1,64}\]$).*$",
             name="configuration",
             previous_priv="privilege_exec",
             deescalate="quit",

--- a/tests/unit/huawei/vrp/test_huawei_vrp.py
+++ b/tests/unit/huawei/vrp/test_huawei_vrp.py
@@ -11,11 +11,15 @@ from scrapli_community.huawei.vrp.huawei_vrp import DEFAULT_PRIVILEGE_LEVELS
         ("privilege_exec", "<SCRAPLI_HUAWEI-VRP_TEST_SW1>"),
         ("configuration", "[SCRAPLI_HUAWEI-VRP_TEST_SW1]"),
         ("configuration", "[SCRAPLI_HUAWEI-VRP_TEST_SW1-GigabitEthernet0/0/1]"),
+        ("configuration", "[~SCRAPLI_HUAWEI-VRP_TEST_SW1]"),
+        ("configuration", "[*SCRAPLI_HUAWEI-VRP_TEST_SW1]"),
     ],
     ids=[
         "ssh_prompt_privilege_exec",
         "ssh_prompt_configuration",
         "ssh_prompt_configuration_interface",
+        "ssh_prompt_configuration",
+        "ssh_prompt_configuration",
     ],
 )
 def test_default_prompt_patterns(priv_pattern):


### PR DESCRIPTION
# Description

Updated ```huawei_vrp``` prompt pattern as these were missing valid characters due to differences between VRP version 8 and version 2. VRP version 8 command prompt has "~" and "*" symbols before a hostname in configuration mode which are absent in VRP version 2. See issue [#117](https://github.com/scrapli/scrapli_community/issues/117) for details.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested the applied changes with modified [```test_huawei_vrp.py```](https://github.com/scrapli/scrapli_community/blob/develop/tests/unit/huawei/vrp/test_huawei_vrp.py).
Tested the applied changes by using this library with the real device in the lab.


# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [ ] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests, please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
