### PR TITLE
Palo response.failed fixes

### DIFF
--- a/scrapli_community/paloalto/panos/paloalto_panos.py
+++ b/scrapli_community/paloalto/panos/paloalto_panos.py
@@ -45,7 +45,7 @@ SCRAPLI_PLATFORM = {
             "Unknown command:",
             "Invalid syntax.",
             "Server error",
-            "Validation Error:",            
+            "Validation Error:",
         ],
         "textfsm_platform": "paloalto_panos",
         "genie_platform": "",

--- a/scrapli_community/paloalto/panos/paloalto_panos.py
+++ b/scrapli_community/paloalto/panos/paloalto_panos.py
@@ -43,8 +43,9 @@ SCRAPLI_PLATFORM = {
         "async_on_close": default_async_on_close,
         "failed_when_contains": [
             "Unknown command:",
-            "Invalid Syntax.",
-            "Validation Error:",
+            "Invalid syntax.",
+            "Server error",
+            "Validation Error:",            
         ],
         "textfsm_platform": "paloalto_panos",
         "genie_platform": "",


### PR DESCRIPTION
# Description

palo_panos -- found issue with incorrect error messages in "failed_when_contains" causing response object to not realize it failed.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

manually testing incorrect commands to ensure they show up as 'failed' properly, without breaking successful commands.

# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions compalints! run `make lint` before
 committing!)
- [N/A] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [N/A] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
