### PR TITLE
Docs fixes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 
 # Checklist:
 
-- [ ] My code follows the style guidelines of this project (no GitHub actions compalints! run `make lint` before
+- [ ] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
  committing!)
 - [ ] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
  docstrings include a summary, args, returns and raises fields (even if N/A)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
       - Installation: user_guide/installation.md
       - Basic Usage: user_guide/basic_usage.md
   - Changelog: changelog.md
+  - Reference: reference/
   - More Scrapli:
     - Scrapli: more_scrapli/scrapli.md
     - Scrapli Netconf: more_scrapli/scrapli_netconf.md
@@ -74,5 +75,4 @@ plugins:
         watch:
         - scrapli_community
     - section-index
-    - literate-nav:
-        nav_file: SUMMARY.md
+    - literate-nav

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,8 +42,8 @@ markdown_extensions:
     - codehilite
     - extra
     - mdx_gh_links:
-        user: mkdocs
-        repo: mkdocs
+        user: scrapli
+        repo: scrapli_community
     - pymdownx.superfences
     - pymdownx.highlight:
         use_pygments: True

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,7 +72,8 @@ plugins:
             paths: [ scrapli_community ]
             options:
               show_signature_annotations: true
-        watch:
-        - scrapli_community
     - section-index
     - literate-nav
+
+watch:
+  - scrapli_community


### PR DESCRIPTION
# Description

While adding my documentation updates in #155 I found some problems which I checked on the current github pages and confirmed to be a problem:
- GitHUB short links like `#155` were pointing to mkdocs GitHUB pages instead of scrapli_community
- Reference menu point was missing
- while building mkdocs pages, it was complaining about deprecation of `watch` feature

I tried to fix those problems, please check the commits to see what's changing!

## Minor problem
The building process logs a lot of these:
```
WARNING  -  griffe: scrapli_community\vyos\vyos\sync_driver.py:15: Failed to get 'exception: description' pair from 'N/A'
WARNING  -  griffe: scrapli_community\vyos\vyos\sync_driver.py:15: Empty exceptions section at line 9
```
I guess it is due to N/A used for Raised docstring which mkdocs doesn't like. I left these alone for now. Just FYI.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

# How Has This Been Tested?

Built docs on my machine and checked the output in browser.

