### PR TITLE
fortinet_fortios - bugfix for initialization

### DIFF
--- a/scrapli_community/fortinet/fortios/async_driver.py
+++ b/scrapli_community/fortinet/fortios/async_driver.py
@@ -60,6 +60,8 @@ class AsyncFortinetFortiOSDriver(AsyncGenericDriver):
             if self._vdoms_enabled:  # we exit from global too
                 disable_paging += "\nend"
             await self.send_commands(disable_paging.splitlines())
+        elif self._vdoms_enabled:
+            await self.context("system")
 
     async def cleanup_session(self) -> None:
         """Restore paging if necessary"""

--- a/scrapli_community/fortinet/fortios/sync_driver.py
+++ b/scrapli_community/fortinet/fortios/sync_driver.py
@@ -60,6 +60,8 @@ class FortinetFortiOSDriver(GenericDriver):
             if self._vdoms_enabled:  # we exit from global too
                 disable_paging += "\nend"
             self.send_commands(disable_paging.splitlines())
+        elif self._vdoms_enabled:
+            self.context("system")
 
     def cleanup_session(self) -> None:
         """Restore paging if necessary"""


### PR DESCRIPTION
# Description

Sorry, found a bug where disabling paging is not necessary in multi VDOM mode and we don't return to system context. That can lead to unexpected behaviors. This change fix this.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on lab device


# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
