### PR TITLE
fix - versa_flexvnf - made space at the end of prompt optional

### DIFF
--- a/scrapli_community/versa/flexvnf/versa_flexvnf.py
+++ b/scrapli_community/versa/flexvnf/versa_flexvnf.py
@@ -9,7 +9,7 @@ from scrapli_community.versa.flexvnf.sync_driver import default_sync_on_close, d
 DEFAULT_PRIVILEGE_LEVELS = {
     "shell": (
         PrivilegeLevel(
-            pattern=r"^\[\w+\@\S+ \S+\] \$ $",
+            pattern=r"^\[\w+\@\S+ \S+\] \$ ?$",
             name="shell",
             previous_priv="",
             deescalate="",
@@ -20,7 +20,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "cli": (
         PrivilegeLevel(
-            pattern=r"^\w+@\S+-cli> $",
+            pattern=r"^\w+@\S+-cli> ?$",
             name="cli",
             previous_priv="shell",
             deescalate="exit",
@@ -31,7 +31,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^\w+@\S+-cli\(\S+\)% $",
+            pattern=r"^\w+@\S+-cli\(\S+\)% ?$",
             name="configuration",
             previous_priv="cli",
             deescalate="exit",


### PR DESCRIPTION
# Description

This is a small bugfix which aims our problem with prompt. For some reason we got similar errors:
``scrapli.exceptions.ScrapliPrivilegeError: could not determine privilege level from provided prompt: 'xxmyuserxx@MYDEVICE-cli(config)%'`` 
The space is missing at the end!!! But the device sends one so determining the prompt fails. My fix basically makes that space optional. This way the login and privilege escalation works. I tested on real box.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

The pytest test still works fine. Also tested on real box.


# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
