### PR TITLE
Added period in hostname

### DIFF
--- a/scrapli_community/nokia/sros/nokia_sros.py
+++ b/scrapli_community/nokia/sros/nokia_sros.py
@@ -14,7 +14,7 @@ from scrapli_community.nokia.sros.sync_driver import (
 DEFAULT_PRIVILEGE_LEVELS = {
     "exec": (
         PrivilegeLevel(
-            pattern=r"^(?!\(ex\)|\(ro\)|\(gl\)|\(pr\))\[.*\]\n[abcd]:[\w\._]+@[\w\s_-]+#\s?$",
+            pattern=r"^(?!\(ex\)|\(ro\)|\(gl\)|\(pr\))\[.*\]\n[abcd]:[\w\._]+@[\w\s_.-]+#\s?$",
             name="exec",
             previous_priv="",
             deescalate="",
@@ -25,7 +25,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^(?:!|\*)?\(ex\)\[\/?\]\n\*?[abcd]:[\w\._]+@[\w\s_-]+#\s?$",
+            pattern=r"^(?:!|\*)?\(ex\)\[\/?\]\n\*?[abcd]:[\w\._]+@[\w\s_.-]+#\s?$",
             name="configuration",
             previous_priv="exec",
             deescalate="quit-config",
@@ -36,7 +36,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration_with_path": (
         PrivilegeLevel(
-            pattern=r"^(?:!|\*)?\(ex\)\[(\S|\s){2,}\]\n\*?[abcd]:[\w\._]+@[\w\s_-]+#\s?$",
+            pattern=r"^(?:!|\*)?\(ex\)\[(\S|\s){2,}\]\n\*?[abcd]:[\w\._]+@[\w\s_.-]+#\s?$",
             name="configuration_with_path",
             previous_priv="exec",
             deescalate="exit all",
@@ -50,7 +50,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
 CLASSIC_DEFAULT_PRIVILEGE_LEVELS = {
     "exec": (
         PrivilegeLevel(
-            pattern=r"^\*?[abcd]:[\w\s_-]+#\s?$",
+            pattern=r"^\*?[abcd]:[\w\s_.-]+#\s?$",
             name="exec",
             previous_priv="",
             deescalate="",
@@ -61,7 +61,7 @@ CLASSIC_DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^\*?[abcd]:[\w\s_-]+>config[\w>]*(#|\$)\s?$",
+            pattern=r"^\*?[abcd]:[\w\s_.-]+>config[\w>]*(#|\$)\s?$",
             name="configuration",
             previous_priv="exec",
             deescalate="exit all",

--- a/tests/unit/nokia/sros/test_nokia_sros.py
+++ b/tests/unit/nokia/sros/test_nokia_sros.py
@@ -54,6 +54,8 @@ def test_default_prompt_patterns(priv_pattern):
         "exec",
         "exec-hyphen",
         "configuration",
+        "exec-period",
+        "configuration-period",
     ],
 )
 def test_default_prompt_patterns_classic_variant(priv_pattern):

--- a/tests/unit/nokia/sros/test_nokia_sros.py
+++ b/tests/unit/nokia/sros/test_nokia_sros.py
@@ -47,6 +47,8 @@ def test_default_prompt_patterns(priv_pattern):
         ("exec", "*A:sr1#"),
         ("exec", "*B:DEV02-XY2#"),
         ("configuration", "*A:sr1>config#"),
+        ("exec", "*A:ear1.sr7s-1# "),
+        ("configuration", "*A:ear1.sr7s-1>config>port# "),
     ],
     ids=[
         "exec",


### PR DESCRIPTION
# Description

Some of our routers have a . (period) in the hostname which was causing the regex prompt match to fail.  

My issue is specifically in the classic variant of the nokia-sros device type but I added this to the default variant matches as well.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

My sample hostname is 'A:ear1.sr7s-1# '.  I modified my locally installed file after working on the regex to allow a "." inside the character list.  The specific portion of the regex was `[\w\s_-]+` and I changed it to `[\w\s_.-]+`.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
 list any relevant details for your test configuration


# Checklist:

- [ ] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [ ] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [ ] New and existing unit tests pass locally with my changes
