### PR TITLE
Datacom dmswitch

### DIFF
--- a/scrapli_community/datacom/dmos/async_driver.py
+++ b/scrapli_community/datacom/dmos/async_driver.py
@@ -19,7 +19,7 @@ async def default_async_on_open(conn: AsyncNetworkDriver) -> None:
 
     """
     await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
-    await conn.send_command(command="screen-length 0 temporary")
+    await conn.send_command(command="paginate false")
 
 
 async def default_async_on_close(conn: AsyncNetworkDriver) -> None:

--- a/scrapli_community/datacom/dmos/datacom_dmos.py
+++ b/scrapli_community/datacom/dmos/datacom_dmos.py
@@ -29,7 +29,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
             name="configuration",
             previous_priv="exec",
             deescalate="exit",
-            escalate="configure terminal",
+            escalate="config terminal",
             escalate_auth=False,
             escalate_prompt="",
         )

--- a/scrapli_community/datacom/dmos/sync_driver.py
+++ b/scrapli_community/datacom/dmos/sync_driver.py
@@ -18,7 +18,7 @@ def default_sync_on_open(conn: NetworkDriver) -> None:
         N/A
     """
     conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
-    conn.send_command(command="screen-length 0 temporary")
+    conn.send_command(command="paginate false")
 
 
 def default_sync_on_close(conn: NetworkDriver) -> None:

--- a/scrapli_community/datacom/dmswitch/__init__.py
+++ b/scrapli_community/datacom/dmswitch/__init__.py
@@ -1,0 +1,4 @@
+"""scrapli_community.datacom.datacom_dmswitch"""
+from scrapli_community.datacom.dmswitch.datacom_dmswitch import SCRAPLI_PLATFORM
+
+__all__ = ("SCRAPLI_PLATFORM",)

--- a/scrapli_community/datacom/dmswitch/async_driver.py
+++ b/scrapli_community/datacom/dmswitch/async_driver.py
@@ -1,0 +1,67 @@
+"""scrapli_community.datacom.dmswitch.async_driver"""
+from typing import Any
+
+from scrapli.driver import AsyncNetworkDriver
+
+
+async def default_async_on_open(conn: AsyncNetworkDriver) -> None:
+    """
+    Async datacom_dmswitch default on_open callable
+
+    Args:
+        conn: AsyncNetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    await conn.send_command(command="configure")
+    await conn.send_command(command="no terminal paging")
+    await conn.send_command(command="exit")
+
+
+async def default_async_on_close(conn: AsyncNetworkDriver) -> None:
+    """
+    Async datacom_dmswitch default on_close callable
+
+    Args:
+        conn: AsyncNetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.channel.write(channel_input="exit")
+    conn.channel.send_return()
+
+
+class AsyncDatacomDmSwitchDriver(AsyncNetworkDriver):
+    def __init__(self, **kwargs: Any) -> None:
+        """
+        Datacom dmswitch platform class
+
+        Args:
+            kwargs: keyword args
+
+        Returns:
+            N/A
+
+        Raises:
+            N/A
+
+        """
+        # *if* using anything but system transport pop out ptyprocess transport options, leaving
+        # anything else
+        transport_plugin = kwargs.get("transport", "system")
+        if transport_plugin != "system":
+            kwargs.get("transport_options", {}).pop("ptyprocess", None)
+
+        super().__init__(**kwargs)

--- a/scrapli_community/datacom/dmswitch/datacom_dmswitch.py
+++ b/scrapli_community/datacom/dmswitch/datacom_dmswitch.py
@@ -29,7 +29,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
             name="configuration",
             previous_priv="exec",
             deescalate="exit",
-            escalate="configure terminal",
+            escalate="configure",
             escalate_auth=False,
             escalate_prompt="",
         )

--- a/scrapli_community/datacom/dmswitch/datacom_dmswitch.py
+++ b/scrapli_community/datacom/dmswitch/datacom_dmswitch.py
@@ -1,0 +1,61 @@
+"""scrapli_community.datacom.dmswitch.datacom_dmswitch"""
+from scrapli.driver.network.base_driver import PrivilegeLevel
+from scrapli_community.datacom.dmswitch.async_driver import (
+    AsyncDatacomDmSwitchDriver,
+    default_async_on_close,
+    default_async_on_open,
+)
+from scrapli_community.datacom.dmswitch.sync_driver import (
+    DatacomDmSwitchDriver,
+    default_sync_on_close,
+    default_sync_on_open,
+)
+
+DEFAULT_PRIVILEGE_LEVELS = {
+    "exec": (
+        PrivilegeLevel(
+            pattern=r"^[\w\.\-]+#\s*$",
+            name="exec",
+            previous_priv="",
+            deescalate="",
+            escalate="",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+    "configuration": (
+        PrivilegeLevel(
+            pattern=r"^[\w\.\-]+\(config\)#\s*$",
+            name="configuration",
+            previous_priv="exec",
+            deescalate="exit",
+            escalate="configure terminal",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+}
+
+SCRAPLI_PLATFORM = {
+    "driver_type": {
+        "sync": DatacomDmSwitchDriver,
+        "async": AsyncDatacomDmSwitchDriver,
+    },
+    "defaults": {
+        "privilege_levels": DEFAULT_PRIVILEGE_LEVELS,
+        "default_desired_privilege_level": "exec",
+        "sync_on_open": default_sync_on_open,
+        "async_on_open": default_async_on_open,
+        "sync_on_close": default_sync_on_close,
+        "async_on_close": default_async_on_close,
+        "failed_when_contains": [
+            "Error:",
+        ],
+        "textfsm_platform": "",
+        "genie_platform": "",
+        # Force the screen to be 256 characters wide.
+        # Might get overwritten by global Scrapli transport options.
+        # See issue #18 for more details.
+        "transport_options": {"ptyprocess": {"cols": 256}},
+    },
+}

--- a/scrapli_community/datacom/dmswitch/sync_driver.py
+++ b/scrapli_community/datacom/dmswitch/sync_driver.py
@@ -1,0 +1,66 @@
+"""scrapli_community.datacom.dmswitch.sync_driver"""
+from typing import Any
+
+from scrapli.driver import NetworkDriver
+
+
+def default_sync_on_open(conn: NetworkDriver) -> None:
+    """
+    Datacom datacom_dmswitch on_open callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+    """
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.send_command(command="configure")
+    conn.send_command(command="no terminal paging")
+    conn.send_command(command="exit")
+
+
+def default_sync_on_close(conn: NetworkDriver) -> None:
+    """
+    datacom_dmswitch default on_close callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.channel.write(channel_input="exit")
+    conn.channel.send_return()
+
+
+class DatacomDmSwitchDriver(NetworkDriver):
+    def __init__(self, **kwargs: Any) -> None:
+        """
+        Datacom dmswitch platform class
+
+        Args:
+            kwargs: keyword args
+
+        Returns:
+            N/A
+
+        Raises:
+            N/A
+
+        """
+        # *if* using anything but system transport pop out ptyprocess transport options, leaving
+        # anything else
+        transport_plugin = kwargs.get("transport", "system")
+        if transport_plugin != "system":
+            kwargs.get("transport_options", {}).pop("ptyprocess", None)
+
+        super().__init__(**kwargs)

--- a/tests/unit/datacom/dmswitch/test_datacom_dmswitch.py
+++ b/tests/unit/datacom/dmswitch/test_datacom_dmswitch.py
@@ -1,0 +1,26 @@
+import re
+
+import pytest
+
+from scrapli_community.datacom.dmswitch.datacom_dmswitch import DEFAULT_PRIVILEGE_LEVELS
+
+
+@pytest.mark.parametrize(
+    "priv_pattern",
+    [
+        ("exec", "SCRAPLI-R1#"),
+        ("configuration", "scrapli_r1(config)#"),
+    ],
+    ids=[
+        "exec",
+        "configuration",
+    ],
+)
+def test_default_prompt_patterns(priv_pattern):
+    priv_level_name = priv_pattern[0]
+    prompt = priv_pattern[1]
+
+    prompt_pattern = DEFAULT_PRIVILEGE_LEVELS.get(priv_level_name).pattern
+    match = re.search(pattern=prompt_pattern, string=prompt, flags=re.M | re.I)
+
+    assert match


### PR DESCRIPTION
# Description

This change is adding a driver for Datacom DmSwitch which covers Datacom devices that still use their legacy NOS (aka DmSwitch). This will allow scrapli automation for Datacom Switches 3000/4000 as well as EDD 2100 series.

Note: I'm also adding two "chore" commits which fixes silly mistakes (wrong commands) from my previous PRs, thanks!

## Type of change

- [ X] New feature (non-breaking change which adds functionality)
- [ X] This change requires a documentation update

# How Has This Been Tested?

This change was validated in a lab environment using DM3000/DM4100/EDD 2102-G2 switches using the following firmwares:
```
EDD-01#show system

Product
-------
 Model:               DmSwitch 2104G2 - EDD (SERIES II)


EDD-01#show firmware
Firmware:
  Version:        5.12
  Compile date:   Tue Sep 23 18:11:32 UTC 2014

Bootloader version: 5.1.4 Oct 10 19:58:10 UTC 2014

---

SW-LAB1#show system

Unit 1
  Product
    Model:               DM4100 - ETH20GT+4GC+4XX+MPLS
    OID:                 1.3.6.1.4.1.3709.1.2.95

SW-LAB1#show firmware
Running firmware:
  Firmware version: 15.2.10
  Stack version:    13
  Compile date:     Tue Mar 26 14:40:57 UTC 2019

Flash firmware:

  ID  Version                      Date                 Flag   Size
  1   15.2.10                      26/03/2019 17:40:57  RS     35379780
```
Also, added the relevant unit tests.

# Checklist:

- [ X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [ X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X ] New and existing unit tests pass locally with my changes


