### PR TITLE
Try to set screen width on Huawei VRP.

### DIFF
--- a/scrapli_community/huawei/vrp/async_driver.py
+++ b/scrapli_community/huawei/vrp/async_driver.py
@@ -33,7 +33,7 @@ async def default_async_on_open(conn: AsyncNetworkDriver) -> None:
     conn.channel.write(channel_input="screen-width 256\ny\n\n")
 
     # Make sure that we have a prompt again, and are not stuck in some confirmation loop.
-    conn.channel.get_prompt()
+    await conn.channel.get_prompt()
 
 
 async def default_async_on_close(conn: AsyncNetworkDriver) -> None:

--- a/scrapli_community/huawei/vrp/async_driver.py
+++ b/scrapli_community/huawei/vrp/async_driver.py
@@ -22,6 +22,19 @@ async def default_async_on_open(conn: AsyncNetworkDriver) -> None:
     await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     await conn.send_command(command="screen-length 0 temporary")
 
+    # Attempt to set screen width as a fallback in case the device does not accept the
+    # ptyprocess/cols property when using system transport (observed on some firmware versions).
+    #
+    # On some devices, the command below might not exist (some switches running < V200R019);
+    # on others it asks for confirmation (Y/N), and other devices accept the command as-is.
+    #
+    # Use write() instead of send_command() or send_interactive() to fail silently should the
+    # command not exist.
+    conn.channel.write(channel_input="screen-width 256\ny\n\n")
+
+    # Make sure that we have a prompt again, and are not stuck in some confirmation loop.
+    conn.channel.get_prompt()
+
 
 async def default_async_on_close(conn: AsyncNetworkDriver) -> None:
     """


### PR DESCRIPTION
# Description

Quick fix to set screen width on Huawei devices.
Accidentally pushed straight to `main` before, sorry about that!

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on production on around ~600 routers and switches running various firmware versions, no issues observed.

# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
