### PR TITLE
add FTD cli support

### DIFF
--- a/docs/reference/cisco/ftd/async_driver.md
+++ b/docs/reference/cisco/ftd/async_driver.md
@@ -1,0 +1,1 @@
+::: cisco.ftd.async_driver

--- a/docs/reference/cisco/ftd/cisco_ftd.md
+++ b/docs/reference/cisco/ftd/cisco_ftd.md
@@ -1,0 +1,3 @@
+::: cisco.ftd.cisco_ftd
+
+# Test

--- a/docs/reference/cisco/ftd/cisco_ftd.md
+++ b/docs/reference/cisco/ftd/cisco_ftd.md
@@ -1,3 +1,1 @@
 ::: cisco.ftd.cisco_ftd
-
-# Test

--- a/docs/reference/cisco/ftd/index.md
+++ b/docs/reference/cisco/ftd/index.md
@@ -1,0 +1,1 @@
+::: cisco.ftd

--- a/docs/reference/cisco/ftd/sync_driver.md
+++ b/docs/reference/cisco/ftd/sync_driver.md
@@ -1,0 +1,1 @@
+::: cisco.ftd.sync_driver

--- a/scrapli_community/cisco/ftd/__init__.py
+++ b/scrapli_community/cisco/ftd/__init__.py
@@ -1,0 +1,5 @@
+"""scrapli_community.cisco.ftd"""
+
+from scrapli_community.cisco.ftd.cisco_ftd import SCRAPLI_PLATFORM
+
+__all__ = ("SCRAPLI_PLATFORM",)

--- a/scrapli_community/cisco/ftd/async_driver.py
+++ b/scrapli_community/cisco/ftd/async_driver.py
@@ -1,0 +1,39 @@
+"""scrapli_community.cisco.ftd.async_driver"""
+
+from scrapli.driver import AsyncNetworkDriver
+
+
+async def default_async_on_open(conn: AsyncNetworkDriver) -> None:
+    """
+    Async cisco_ftd default on_open callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+
+
+async def default_async_on_close(conn: AsyncNetworkDriver) -> None:
+    """
+    Async cisco_ftd default on_close callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.channel.write(channel_input="logout")
+    conn.channel.send_return()

--- a/scrapli_community/cisco/ftd/cisco_ftd.py
+++ b/scrapli_community/cisco/ftd/cisco_ftd.py
@@ -1,0 +1,94 @@
+"""scrapli_community.cisco.ftd.cisco_ftd
+
+Welcome to infamous FTD CLI driver!
+If you are so desperate to run this code, you have to know a couple of things:
+
+* Always use full words for commands!
+  Otherwise, your connection will stall because FTD tries to complete it and it confuses Scrapli logic.
+  E.g.: DO NOT do this: conn.send_command("show run"), instead: conn.send_command("show running-config")
+
+* Do not use CLI filters without testing first!
+  Commands like: show failover | include This host:.*Active
+  might fail because prompt is handled strangely by FTD. In this case, just do not filter on the CLI but in your code.
+  Filters are buggy anyway: simple regex expressions don't work. E.g. parentheses.
+  In the worst case, set `eager` to True.
+
+* If you want to run commands in expert/root mode, you need to specify desired_privilege_level by connection data and
+  specify auth_secondary (admin password)!
+  data = {
+    "host": "172.18.0.11",
+    "platform": "cisco_ftd",
+    "auth_username": "scrapli",
+    "auth_password": "scrapli",
+    "auth_secondary": "scrapli",
+    "auth_strict_key": False,
+    #"default_desired_privilege_level": "root",  # only use this if you want to run linux commands!
+  }
+  with Scrapli(**data) as conn:
+    ...
+
+"""
+
+
+from scrapli.driver.network.base_driver import PrivilegeLevel
+from scrapli_community.cisco.ftd.async_driver import (
+    default_async_on_close,
+    default_async_on_open,
+)
+from scrapli_community.cisco.ftd.sync_driver import (
+    default_sync_on_close,
+    default_sync_on_open,
+)
+
+DEFAULT_PRIVILEGE_LEVELS = {
+    "exec": (
+        PrivilegeLevel(
+            pattern=r"^>\s*",
+            name="exec",
+            previous_priv="",
+            deescalate="",
+            escalate="",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+    "expert": (
+        PrivilegeLevel(
+            pattern=r"^[\w.-]{1,63}@[^$]+\$\s*$",
+            name="expert",
+            previous_priv="exec",
+            deescalate="exit",
+            escalate="expert",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+    "root": (
+        PrivilegeLevel(
+            pattern=r"^root@[^#]+#\s*$",
+            name="root",
+            previous_priv="expert",
+            deescalate="exit",
+            escalate="sudo su -",
+            escalate_auth=True,
+            escalate_prompt="Password:"
+        )
+    )
+}
+
+SCRAPLI_PLATFORM = {
+    "driver_type": "network",
+    "defaults": {
+        "privilege_levels": DEFAULT_PRIVILEGE_LEVELS,
+        "default_desired_privilege_level": "exec",  # set this by connection data if needed
+        "sync_on_open": default_sync_on_open,
+        "async_on_open": default_async_on_open,
+        "sync_on_close": default_sync_on_close,
+        "async_on_close": default_async_on_close,
+        "failed_when_contains": [
+            "Syntax error:",
+        ],
+        "textfsm_platform": "cisco_ftd",  # hardly supported, don't count on it
+        # "genie_platform": "ftd",  # not supported
+    },
+}

--- a/scrapli_community/cisco/ftd/cisco_ftd.py
+++ b/scrapli_community/cisco/ftd/cisco_ftd.py
@@ -5,16 +5,20 @@ Welcome to infamous FTD CLI driver!
 If you are so desperate to run this code, you have to know a couple of things:
 
 * Always use full words for commands!
-  Otherwise, your connection will stall because FTD tries to complete it and it confuses Scrapli logic.
-  E.g.: DO NOT do this: conn.send_command("show run"), instead: conn.send_command("show running-config")
+  Otherwise, your connection will stall because FTD tries to complete it and it confuses Scrapli
+  logic.
+  E.g.: DO NOT do this: conn.send_command("show run"), instead:
+  conn.send_command("show running-config")
 
 * Do not use CLI filters without testing first!
   Commands like: show failover | include This host:.*Active
-  might fail because prompt is handled strangely by FTD. In this case, just do not filter on the CLI but in your code.
+  might fail because prompt is handled strangely by FTD. In this case, just do not filter on the
+  CLI but in your code.
   Filters are buggy anyway: simple regex expressions don't work. E.g. parentheses.
   In the worst case, set `eager` to True.
 
-* If you want to run commands in expert/root mode, you need to specify desired_privilege_level by connection data and
+* If you want to run commands in expert/root mode, you need to specify desired_privilege_level by
+ connection data and
   specify auth_secondary (admin password)!
   data = {
     "host": "172.18.0.11",

--- a/scrapli_community/cisco/ftd/cisco_ftd.py
+++ b/scrapli_community/cisco/ftd/cisco_ftd.py
@@ -1,4 +1,5 @@
-"""scrapli_community.cisco.ftd.cisco_ftd
+"""
+scrapli_community.cisco.ftd.cisco_ftd
 
 Welcome to infamous FTD CLI driver!
 If you are so desperate to run this code, you have to know a couple of things:
@@ -29,16 +30,9 @@ If you are so desperate to run this code, you have to know a couple of things:
 
 """
 
-
 from scrapli.driver.network.base_driver import PrivilegeLevel
-from scrapli_community.cisco.ftd.async_driver import (
-    default_async_on_close,
-    default_async_on_open,
-)
-from scrapli_community.cisco.ftd.sync_driver import (
-    default_sync_on_close,
-    default_sync_on_open,
-)
+from scrapli_community.cisco.ftd.async_driver import default_async_on_close, default_async_on_open
+from scrapli_community.cisco.ftd.sync_driver import default_sync_on_close, default_sync_on_open
 
 DEFAULT_PRIVILEGE_LEVELS = {
     "exec": (
@@ -71,9 +65,9 @@ DEFAULT_PRIVILEGE_LEVELS = {
             deescalate="exit",
             escalate="sudo su -",
             escalate_auth=True,
-            escalate_prompt="Password:"
+            escalate_prompt="Password:",
         )
-    )
+    ),
 }
 
 SCRAPLI_PLATFORM = {

--- a/scrapli_community/cisco/ftd/sync_driver.py
+++ b/scrapli_community/cisco/ftd/sync_driver.py
@@ -1,0 +1,39 @@
+"""scrapli_community.cisco.ftd.sync_driver"""
+
+from scrapli.driver import NetworkDriver
+
+
+def default_sync_on_open(conn: NetworkDriver) -> None:
+    """
+    Async cisco_ftd default on_open callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+
+
+def default_sync_on_close(conn: NetworkDriver) -> None:
+    """
+    cisco_ftd default on_close callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+
+    """
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.channel.write(channel_input="logout")
+    conn.channel.send_return()

--- a/tests/unit/cisco/ftd/test_cisco_ftd.py
+++ b/tests/unit/cisco/ftd/test_cisco_ftd.py
@@ -1,0 +1,32 @@
+import re
+
+import pytest
+
+from scrapli_community.cisco.ftd.cisco_ftd import DEFAULT_PRIVILEGE_LEVELS
+
+
+@pytest.mark.parametrize(
+    "priv_pattern",
+    [
+        ("exec", ">"),
+        ("exec", "> "),
+        ("expert", "my-user@ACME-FIREWALL:~$"),
+        ("expert", "my-user@ACME-FIREWALL:~$ "),
+        ("root", "root@ACME-FIREWALL:~#"),
+        ("root", "root@ACME-FIREWALL:~# "),
+    ],
+    ids=[
+        "base_prompt_exec",
+        "base_prompt_exec_space",
+        "base_prompt_expert",
+        "base_prompt_expert_space",
+        "base_prompt_root",
+        "base_prompt_root_space",
+    ],
+)
+def test_default_prompt_patterns(priv_pattern):
+    priv_level_name = priv_pattern[0]
+    prompt = priv_pattern[1]
+    prompt_pattern = DEFAULT_PRIVILEGE_LEVELS.get(priv_level_name).pattern
+    match = re.search(pattern=prompt_pattern, string=prompt, flags=re.M | re.I)
+    assert match


### PR DESCRIPTION
# Cisco FTD (FirePower Threat Defense) driver added

I needed an FTD driver for my project, so I created it and share hereby. Please do not use this as FTD doesn't like you messing with its CLI. But if you are like me and want to do it anyway, now you have a way via Scrapli.
There are couple of use cases which may interest you with this:
* pre-configuration of certain CLI only items like `manager`
* getting ACL configuration
* getting failover status
* etc...

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I tested it in my environment. The small pytest test-case is only for prompt testing.


# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
