### PR TITLE
feat(nokia_sros): Added a variant for Nokia DSLAMs, models: ARAM F, etc

### DIFF
--- a/scrapli_community/nokia/sros/async_driver.py
+++ b/scrapli_community/nokia/sros/async_driver.py
@@ -40,6 +40,26 @@ async def classic_default_async_on_open(conn: AsyncNetworkDriver) -> None:
     await conn.send_command(command="environment no more")
 
 
+async def classic_aram_async_on_open(conn: AsyncNetworkDriver) -> None:
+    """
+    nokia_sros aram on_open callable
+
+    Args:
+        conn: AsyncNetworkDriver object
+
+    Returns:
+        None
+
+    Raises:
+        N/A
+    """
+    await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    await conn.send_command(command="environment mode batch")
+    await conn.send_command(command="environment inhibit-alarms")
+    await conn.send_command(command="environment print no-more")
+    await conn.send_command(command="exit all")
+
+
 async def default_async_on_close(conn: AsyncNetworkDriver) -> None:
     """
     nokia_sros default on_close callable

--- a/scrapli_community/nokia/sros/nokia_sros.py
+++ b/scrapli_community/nokia/sros/nokia_sros.py
@@ -87,17 +87,6 @@ CLASSIC_ARAM_PRIVILEGE_LEVELS = {
             escalate_prompt="",
         )
     ),
-    "configuration": (
-        PrivilegeLevel(
-            pattern=r"^(.*)[a-zA-Z0-9_\:\-\>]*[\#\$] ?$",
-            name="configuration",
-            previous_priv="",
-            deescalate="exit all",
-            escalate="",
-            escalate_auth=False,
-            escalate_prompt="",
-        )
-    ),
 }
 
 SCRAPLI_PLATFORM = {

--- a/scrapli_community/nokia/sros/nokia_sros.py
+++ b/scrapli_community/nokia/sros/nokia_sros.py
@@ -2,11 +2,13 @@
 
 from scrapli.driver.network.base_driver import PrivilegeLevel
 from scrapli_community.nokia.sros.async_driver import (
+    classic_aram_async_on_open,
     classic_default_async_on_open,
     default_async_on_close,
     default_async_on_open,
 )
 from scrapli_community.nokia.sros.sync_driver import (
+    classic_aram_sync_on_open,
     classic_default_sync_on_open,
     default_sync_on_close,
     default_sync_on_open,
@@ -73,6 +75,30 @@ CLASSIC_DEFAULT_PRIVILEGE_LEVELS = {
     ),
 }
 
+CLASSIC_ARAM_PRIVILEGE_LEVELS = {
+    "exec": (
+        PrivilegeLevel(
+            pattern=r"^(.*)[a-zA-Z0-9_\:\-\>]*[\#\$] ?$",
+            name="exec",
+            previous_priv="",
+            deescalate="",
+            escalate="",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+    "configuration": (
+        PrivilegeLevel(
+            pattern=r"^(.*)[a-zA-Z0-9_\:\-\>]*[\#\$] ?$",
+            name="configuration",
+            previous_priv="",
+            deescalate="exit all",
+            escalate="",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+}
 
 SCRAPLI_PLATFORM = {
     "driver_type": "network",
@@ -100,6 +126,16 @@ SCRAPLI_PLATFORM = {
                 "MAJOR:",
                 "Error:",
                 "Bad Command:",
+            ],
+        },
+        "aram": {
+            "privilege_levels": CLASSIC_ARAM_PRIVILEGE_LEVELS,
+            "sync_on_open": classic_aram_sync_on_open,
+            "async_on_open": classic_aram_async_on_open,
+            "timeout_ops": 300,
+            "failed_when_contains": [
+                "command is not complete",
+                "invalid token",
             ],
         },
     },

--- a/scrapli_community/nokia/sros/sync_driver.py
+++ b/scrapli_community/nokia/sros/sync_driver.py
@@ -40,6 +40,26 @@ def classic_default_sync_on_open(conn: NetworkDriver) -> None:
     conn.send_command(command="environment no more")
 
 
+def classic_aram_sync_on_open(conn: NetworkDriver) -> None:
+    """
+    nokia_sros aram mode on_open callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        None
+
+    Raises:
+        N/A
+    """
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.send_command(command="environment mode batch")
+    conn.send_command(command="environment inhibit-alarms")
+    conn.send_command(command="environment print no-more")
+    conn.send_command(command="exit all")
+
+
 def default_sync_on_close(conn: NetworkDriver) -> None:
     """
     nokia_sros default on_close callable

--- a/tests/unit/nokia/sros/test_nokia_sros.py
+++ b/tests/unit/nokia/sros/test_nokia_sros.py
@@ -71,11 +71,8 @@ def test_default_prompt_patterns_classic_variant(priv_pattern):
 
 @pytest.mark.parametrize(
     "priv_pattern",
-    [("exec", "leg:noa>#"), ("configuration", "leg:noa>#")],
-    ids=[
-        "exec",
-        "configuration",
-    ],
+    [("exec", "leg:noa>#")],
+    ids=["exec"],
 )
 def test_default_prompt_patterns_classic_aram_variant(priv_pattern):
     priv_level_name = priv_pattern[0]

--- a/tests/unit/nokia/sros/test_nokia_sros.py
+++ b/tests/unit/nokia/sros/test_nokia_sros.py
@@ -3,6 +3,7 @@ import re
 import pytest
 
 from scrapli_community.nokia.sros.nokia_sros import (
+    CLASSIC_ARAM_PRIVILEGE_LEVELS,
     CLASSIC_DEFAULT_PRIVILEGE_LEVELS,
     DEFAULT_PRIVILEGE_LEVELS,
 )
@@ -63,6 +64,24 @@ def test_default_prompt_patterns_classic_variant(priv_pattern):
     prompt = priv_pattern[1]
 
     prompt_pattern = CLASSIC_DEFAULT_PRIVILEGE_LEVELS.get(priv_level_name).pattern
+    match = re.search(pattern=prompt_pattern, string=prompt, flags=re.M | re.I)
+
+    assert match
+
+
+@pytest.mark.parametrize(
+    "priv_pattern",
+    [("exec", "leg:noa>#"), ("configuration", "leg:noa>#")],
+    ids=[
+        "exec",
+        "configuration",
+    ],
+)
+def test_default_prompt_patterns_classic_aram_variant(priv_pattern):
+    priv_level_name = priv_pattern[0]
+    prompt = priv_pattern[1]
+
+    prompt_pattern = CLASSIC_ARAM_PRIVILEGE_LEVELS.get(priv_level_name).pattern
     match = re.search(pattern=prompt_pattern, string=prompt, flags=re.M | re.I)
 
     assert match


### PR DESCRIPTION

# Description

feat(nokia_sros): Added a variant for Nokia DSLAMs, models: ARAM F, ARAM FD and ARAM D.

I'm working with some automation tasks on Nokia DSLAMs. I'm migrating from pyats-genie/unicon to scrapli and decided to create a variant on Nokia SROS because classic OS behave almost the same as the Nokia ARAM DSLAM OS.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

I have tested this variant on production devices. Nokia DSLAMs, models: ARAM F, ARAM FD and ARAM D.


# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
