### PR TITLE
Adding Zyxel IES DSLAMs driver support

### DIFF
--- a/scrapli_community/zyxel/dslam/__init__.py
+++ b/scrapli_community/zyxel/dslam/__init__.py
@@ -1,0 +1,5 @@
+"""scrapli_community.scrapli.networkdriver"""
+
+from scrapli_community.zyxel.dslam.zyxel_dslam import SCRAPLI_PLATFORM
+
+__all__ = ("SCRAPLI_PLATFORM",)

--- a/scrapli_community/zyxel/dslam/async_driver.py
+++ b/scrapli_community/zyxel/dslam/async_driver.py
@@ -1,0 +1,64 @@
+"""scrapli_community.zyxel.dslam.zyxel_dslam"""
+
+from time import sleep
+from typing import Any
+
+from scrapli.driver import AsyncNetworkDriver
+
+
+async def default_async_on_open(conn: AsyncNetworkDriver) -> None:
+    """
+    Async zyxel_dslam default on_open callable
+
+    Args:
+        conn: AsyncNetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+    """
+    await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+
+
+async def default_async_on_close(conn: AsyncNetworkDriver) -> None:
+    """
+    Async zyxel_dslam default on_close callable
+
+    Args:
+        conn: AsyncNetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+    """
+    # write exit directly to the transport as channel would fail to find the prompt after sending
+    # the exit command!
+    # sleep is required to ensure the exit command is processed before the connection is closed
+    # otherwise ssh2.exceptions.SocketRecvError is triggered
+    await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.channel.write(channel_input="exit")
+    conn.channel.send_return()
+    sleep(0.1)
+
+
+class AsyncZyxelDSLAMDriver(AsyncNetworkDriver):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """
+        Zyxel DSLAM community platform class
+
+        Args:
+            args: positional args
+            kwargs: keyword args
+
+        Returns:
+            N/A
+
+        Raises:
+            N/A
+
+        """
+        super().__init__(*args, **kwargs)

--- a/scrapli_community/zyxel/dslam/sync_driver.py
+++ b/scrapli_community/zyxel/dslam/sync_driver.py
@@ -1,0 +1,64 @@
+"""scrapli_community.zyxel.dslam.zyxel_dslam"""
+
+from time import sleep
+from typing import Any
+
+from scrapli.driver import NetworkDriver
+
+
+def default_sync_on_open(conn: NetworkDriver) -> None:
+    """
+    zyxel_dslam default on_open callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+    """
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+
+
+def default_sync_on_close(conn: NetworkDriver) -> None:
+    """
+    zyxel_dslam default on_close callable
+
+    Args:
+        conn: NetworkDriver object
+
+    Returns:
+        N/A
+
+    Raises:
+        N/A
+    """
+    # write exit directly to the transport as channel would fail to find the prompt after sending
+    # the exit command!
+    # sleep is required to ensure the exit command is processed before the connection is closed
+    # otherwise ssh2.exceptions.SocketRecvError is triggered
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
+    conn.channel.write(channel_input="exit")
+    conn.channel.send_return()
+    sleep(0.1)
+
+
+class ZyxelDSLAMDriver(NetworkDriver):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """
+        Zyxel DSLAM community platform class
+
+        Args:
+            args: positional args
+            kwargs: keyword args
+
+        Returns:
+            N/A
+
+        Raises:
+            N/A
+
+        """
+        super().__init__(*args, **kwargs)

--- a/scrapli_community/zyxel/dslam/zyxel_dslam.py
+++ b/scrapli_community/zyxel/dslam/zyxel_dslam.py
@@ -24,17 +24,6 @@ DEFAULT_PRIVILEGE_LEVELS = {
             escalate_prompt="",
         )
     ),
-    "configuration": (
-        PrivilegeLevel(
-            pattern=r"^(.*)[a-zA-Z0-9_\-]*[\>#]\s*$",
-            name="configuration",
-            previous_priv="",
-            deescalate="",
-            escalate="",
-            escalate_auth=False,
-            escalate_prompt="",
-        )
-    ),
 }
 
 SCRAPLI_PLATFORM = {

--- a/scrapli_community/zyxel/dslam/zyxel_dslam.py
+++ b/scrapli_community/zyxel/dslam/zyxel_dslam.py
@@ -1,0 +1,60 @@
+"""scrapli_community.zyxel.dslam.zyxel_dslam"""
+
+from scrapli.driver.network.base_driver import PrivilegeLevel
+from scrapli_community.zyxel.dslam.async_driver import (
+    AsyncZyxelDSLAMDriver,
+    default_async_on_close,
+    default_async_on_open,
+)
+from scrapli_community.zyxel.dslam.sync_driver import (
+    ZyxelDSLAMDriver,
+    default_sync_on_close,
+    default_sync_on_open,
+)
+
+DEFAULT_PRIVILEGE_LEVELS = {
+    "exec": (
+        PrivilegeLevel(
+            pattern=r"^(.*)[a-zA-Z0-9_\-]*[\>#]\s*$",
+            name="exec",
+            previous_priv="",
+            deescalate="",
+            escalate="",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+    "configuration": (
+        PrivilegeLevel(
+            pattern=r"^(.*)[a-zA-Z0-9_\-]*[\>#]\s*$",
+            name="configuration",
+            previous_priv="",
+            deescalate="",
+            escalate="",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+}
+
+SCRAPLI_PLATFORM = {
+    "driver_type": {
+        "sync": ZyxelDSLAMDriver,
+        "async": AsyncZyxelDSLAMDriver,
+    },
+    "defaults": {
+        "privilege_levels": DEFAULT_PRIVILEGE_LEVELS,
+        "default_desired_privilege_level": "exec",
+        "sync_on_open": default_sync_on_open,
+        "async_on_open": default_async_on_open,
+        "sync_on_close": default_sync_on_close,
+        "async_on_close": default_async_on_close,
+        "timeout_ops": 300,
+        "failed_when_contains": [
+            "invalid command",
+            "command authorization fail",
+        ],
+        "textfsm_platform": "zyxel_dslam",
+        "genie_platform": "",
+    },
+}

--- a/tests/unit/zyxel/dslam/test_zyxel_dslam.py
+++ b/tests/unit/zyxel/dslam/test_zyxel_dslam.py
@@ -9,11 +9,9 @@ from scrapli_community.zyxel.dslam.zyxel_dslam import DEFAULT_PRIVILEGE_LEVELS
     "priv_pattern",
     [
         ("exec", "ZSCRAPLI_DSLAM>"),
-        ("configuration", "ZSCRAPLI_CNF_DSLAM>"),
     ],
     ids=[
         "ssh_prompt_exec",
-        "ssh_prompt_configuration",
     ],
 )
 def test_default_prompt_patterns(priv_pattern):

--- a/tests/unit/zyxel/dslam/test_zyxel_dslam.py
+++ b/tests/unit/zyxel/dslam/test_zyxel_dslam.py
@@ -1,0 +1,26 @@
+import re
+
+import pytest
+
+from scrapli_community.zyxel.dslam.zyxel_dslam import DEFAULT_PRIVILEGE_LEVELS
+
+
+@pytest.mark.parametrize(
+    "priv_pattern",
+    [
+        ("exec", "ZSCRAPLI_DSLAM>"),
+        ("configuration", "ZSCRAPLI_CNF_DSLAM>"),
+    ],
+    ids=[
+        "ssh_prompt_exec",
+        "ssh_prompt_configuration",
+    ],
+)
+def test_default_prompt_patterns(priv_pattern):
+    priv_level_name = priv_pattern[0]
+    prompt = priv_pattern[1]
+
+    prompt_pattern = DEFAULT_PRIVILEGE_LEVELS.get(priv_level_name).pattern
+    match = re.search(pattern=prompt_pattern, string=prompt, flags=re.M | re.I)
+
+    assert match


### PR DESCRIPTION
# Description

Adding Zyxel IES DSLAMs driver support.

I'm working with some automation tasks on  Zyxel IES 5000 Series DSLAMs. I'm migrating my implementations from pyats-genie/unicon to scrapli and decided to create a new driver for Zyxel IES 5000 Series DSLAMs. These are legacy devices and the Operating system doesn't have a name. 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

I have tested this driver on production devices. Zyxel IES 5000 Series DSLAMs.


# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
