### PR TITLE
Fixes and new feature for Huawei SmartAX new

### DIFF
--- a/scrapli_community/huawei/smartax/async_driver.py
+++ b/scrapli_community/huawei/smartax/async_driver.py
@@ -41,6 +41,8 @@ async def default_async_on_close(conn: AsyncNetworkDriver) -> None:
     await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     conn.channel.write(channel_input="quit")
     conn.channel.send_return()
+    conn.channel.write(channel_input="y")
+    conn.channel.send_return()
 
 
 class AsyncHuaweiSmartAXDriver(AsyncNetworkDriver):

--- a/scrapli_community/huawei/smartax/huawei_smartax.py
+++ b/scrapli_community/huawei/smartax/huawei_smartax.py
@@ -29,7 +29,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
             pattern=r"^\S{1,48}#$",
             name="privilege_exec",
             previous_priv="exec",
-            deescalate="quit",
+            deescalate="disable",
             escalate="enable",
             escalate_auth=False,
             escalate_prompt="",
@@ -37,11 +37,22 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^\S{1,48}\(config(\-\S+)+\)|\(config\)#$",
+            pattern=r"^(.*)\(.*(config)\S*\)#$",
             name="configuration",
             previous_priv="privilege_exec",
             deescalate="quit",
-            escalate="enable",
+            escalate="config",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+    "diagnose": (
+        PrivilegeLevel(
+            pattern=r".*\(diagnose\)\%\%$",
+            name="diagnose",
+            previous_priv="privilege_exec",
+            deescalate="quit",
+            escalate="diagnose",
             escalate_auth=False,
             escalate_prompt="",
         )
@@ -60,12 +71,14 @@ SCRAPLI_PLATFORM = {
         "async_on_open": default_async_on_open,
         "sync_on_close": default_sync_on_close,
         "async_on_close": default_async_on_close,
-        "failed_when_contains": ["Error:"],
-        "textfsm_platform": "huawei_vrp",
+        "failed_when_contains": [
+            "% Ambiguous command",
+            "% Incomplete command",
+            "% Invalid input detected",
+            "% Unknown command",
+            "Error:",
+        ],
+        "textfsm_platform": "huawei_smartax",
         "genie_platform": "",
-        # Force the screen to be 256 characters wide.
-        # Might get overwritten by global Scrapli transport options.
-        # See issue #18 for more details.
-        "transport_options": {"ptyprocess": {"cols": 256}},
     },
 }

--- a/scrapli_community/huawei/smartax/sync_driver.py
+++ b/scrapli_community/huawei/smartax/sync_driver.py
@@ -19,7 +19,6 @@ def default_sync_on_open(conn: NetworkDriver) -> None:
         N/A
     """
     conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
-    conn.send_command(command="screen-length 0 temporary")
     conn.send_command(command="undo smart")
     conn.send_command(command="scroll")
 
@@ -40,6 +39,8 @@ def default_sync_on_close(conn: NetworkDriver) -> None:
     """
     conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     conn.channel.write(channel_input="quit")
+    conn.channel.send_return()
+    conn.channel.write(channel_input="y")
     conn.channel.send_return()
 
 

--- a/tests/unit/huawei/smartax/test_huawei_smartax.py
+++ b/tests/unit/huawei/smartax/test_huawei_smartax.py
@@ -12,12 +12,14 @@ from scrapli_community.huawei.smartax.huawei_smartax import DEFAULT_PRIVILEGE_LE
         ("privilege_exec", "SCRAPLI_HUAWEI-SMARTAX_TEST_OLT1#"),
         ("configuration", "SCRAPLI_HUAWEI-SMARTAX_TEST_OLT1(config)#"),
         ("configuration", "SCRAPLI_HUAWEI-SMARTAX_TEST_OLT1(config-if-gpon-0/1)#"),
+        ("diagnose", "SCRAPLI_HUAWEI-SMARTAX_TEST_OLT1(diagnose)%%"),
     ],
     ids=[
         "ssh_prompt_non_privileged_exec",
         "ssh_prompt_privilege_exec",
         "ssh_prompt_configuration",
         "ssh_prompt_configuration_interface",
+        "ssh_prompt_diagnose",
     ],
 )
 def test_default_prompt_patterns(priv_pattern):


### PR DESCRIPTION
# Description

1 - On default_async_on_close added "y" input, because when quitting …it ask for confirmation. Example:
SCRAPLI_EXAMPLE>quit
  Check whether system data has been changed. Please save data before logout. Are you sure to log out? (y/n)[n]:y

2 - Fix: On privilege_exec, deescalate with command "disable" 
3 - Fix: On configuration, escalate with command "config" and changed pattern to one that match more names. 
4 - Added Privilege level "diagnose".
5 - Added more failed text
6 - "textfsm_platform" updated to one dedicated to smartax 
7 - In default_sync_on_open removed command "screen-length 0 temporary", wrong OS and not needed.
8 - Removed "transport_options": {"ptyprocess": {"cols": 256}}, Issue 18 do not apply to this operating system.

I'm working with some automation tasks on Huawei Smartx MA5800 and also old MA5600  model. I'm migrating from pyats-genie/unicon to scrapli and decided to test and analyze the existing driver. I noticed it required some fixes and also needed to add some features.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

All these changes were tested with production devices, two different models:

- Huawei MA5800 and MA5600

# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
