### PR TITLE
fix(mikrotik_routeros): remove login option 'e'

### DIFF
--- a/scrapli_community/mikrotik/routeros/async_driver.py
+++ b/scrapli_community/mikrotik/routeros/async_driver.py
@@ -42,7 +42,7 @@ class AsyncMikrotikRouterOSDriver(AsyncGenericDriver):
 
         # Append login options to the username according to
         # https://wiki.mikrotik.com/wiki/Manual:Console_login_process
-        kwargs["auth_username"] += "+cet511w4098h"
+        kwargs["auth_username"] += "+ct511w4098h"
 
         super().__init__(**kwargs)
 

--- a/scrapli_community/mikrotik/routeros/async_driver.py
+++ b/scrapli_community/mikrotik/routeros/async_driver.py
@@ -42,7 +42,8 @@ class AsyncMikrotikRouterOSDriver(AsyncGenericDriver):
 
         # Append login options to the username according to
         # https://wiki.mikrotik.com/wiki/Manual:Console_login_process
-        kwargs["auth_username"] += "+ct511w4098h"
+        kwargs["auth_username"] += kwargs["routeros_login_options"]
+        kwargs.pop("routeros_login_options")
 
         super().__init__(**kwargs)
 

--- a/scrapli_community/mikrotik/routeros/mikrotik_routeros.py
+++ b/scrapli_community/mikrotik/routeros/mikrotik_routeros.py
@@ -21,5 +21,7 @@ SCRAPLI_PLATFORM = {
         "async_on_open": None,
         "sync_on_close": default_sync_on_close,
         "async_on_close": default_async_on_close,
+        "routeros_login_options": "+ct511w4098h",
     },
+    "variants": {"with_login_option_e": {"routeros_login_options": "+cet511w4098h"}},
 }

--- a/scrapli_community/mikrotik/routeros/sync_driver.py
+++ b/scrapli_community/mikrotik/routeros/sync_driver.py
@@ -42,7 +42,8 @@ class MikrotikRouterOSDriver(GenericDriver):
 
         # Append login options to the username according to
         # https://wiki.mikrotik.com/wiki/Manual:Console_login_process
-        kwargs["auth_username"] += "+ct511w4098h"
+        kwargs["auth_username"] += kwargs["routeros_login_options"]
+        kwargs.pop("routeros_login_options")
 
         super().__init__(**kwargs)
 

--- a/scrapli_community/mikrotik/routeros/sync_driver.py
+++ b/scrapli_community/mikrotik/routeros/sync_driver.py
@@ -42,7 +42,7 @@ class MikrotikRouterOSDriver(GenericDriver):
 
         # Append login options to the username according to
         # https://wiki.mikrotik.com/wiki/Manual:Console_login_process
-        kwargs["auth_username"] += "+cet511w4098h"
+        kwargs["auth_username"] += "+ct511w4098h"
 
         super().__init__(**kwargs)
 


### PR DESCRIPTION
# Description

Fixes #185 

Login option `e` makes the RouterOS terminal enter a "dumb" mode ([for reference](https://help.mikrotik.com/docs/spaces/ROS/pages/328134/Command+Line+Interface#CommandLineInterface-LoginOptions)) which forces a newline each time a character is sent to the device.
Parsing that in the model fails often.


Omitting the option improves the reliability of parsing command output.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested by connecting to a live device, and running various `print` commands.


# Checklist:

- [ ] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [ ] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [ ] New and existing unit tests pass locally with my changes
