### PR TITLE
changes to gather_vdom

### DIFF
--- a/scrapli_community/fortinet/fortios/sync_driver.py
+++ b/scrapli_community/fortinet/fortios/sync_driver.py
@@ -87,8 +87,9 @@ class FortinetFortiOSDriver(GenericDriver):
             This won't exit deeply nested config blocks!
         """
         prompt = self.get_prompt()
-        if "(" in prompt:
+        while "(" in prompt:
             self.send_commands(["abort", "end"])
+            prompt = self.get_prompt()
 
     def gather_vdoms(self) -> Union[None, List[str]]:
         """Gather list of VDOMs
@@ -102,19 +103,17 @@ class FortinetFortiOSDriver(GenericDriver):
             # device is not in multi VDOM mode
             return None
         self._to_system()
-        output = self.send_command('show | grep "config vdom" -f -A1')
-        # """
-        # FIREWALL # show | grep "config vdom" -f -A1
-        # config vdom
-        # edit root
-        # --
-        # config vdom
-        # edit root
-        # --
-        # config vdom
-        # edit test1
-        # """
-        self._vdom_list = list(set(re.findall(r"^edit (\w+)$", output.result, re.M)))
+        self.send_command('config global')
+        output = self.send_command('diagnose sys vd list')
+        self._to_system()
+
+        # Valid characters for VDOM name - 0-9, A-Z, a-z, -, _
+        vd_list = re.findall(r"name=([0-9A-Za-z-_]+)", output.result)
+
+        # Removal of system-defined VDOMs (vsys_.*)
+        vsys_re = re.compile(r"^vsys_")
+        self._vdom_list = [vd for vd in vd_list if not vsys_re.match(vd)]
+
         return self._vdom_list
 
     def context(self, context: str) -> Union[None, str]:


### PR DESCRIPTION
# Description

Currently, FortiOS_Driver uses an painstakingly long command to capture all available VDOMs of a FortiGate ('show | grep "config vdom" -f -A1'). When configuration become longer, it takes more time. So, I have proposed (in an issue) to change it to "diagnose sys vd list". Also, VDOM name can have any alphanumeric character along with "-" and "_".

# How Has This Been Tested?

FortiGates running on v7.2.10/11 and with/without VDOMs.
