### PR TITLE
Ruckus fastiron parentheses support

### DIFF
--- a/scrapli_community/ruckus/fastiron/ruckus_fastiron.py
+++ b/scrapli_community/ruckus/fastiron/ruckus_fastiron.py
@@ -24,7 +24,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "privilege_exec": (
         PrivilegeLevel(
-            pattern=r"^[a-z0-9 .\-_@/:]{1,63}#$",
+            pattern=r"^[a-z0-9 .\-_@()/:]{1,63}#$",
             name="privilege_exec",
             previous_priv="exec",
             deescalate="quit",
@@ -35,7 +35,7 @@ DEFAULT_PRIVILEGE_LEVELS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^[a-z0-9 .\-_@/:]{1,63}\(conf[a-z0-9.\-@/:\+]{0,32}\)#$",
+            pattern=r"^[a-z0-9 .\-_@()/:]{1,63}\(conf[a-z0-9.\-@/:\+]{0,32}\)#$",
             name="configuration",
             previous_priv="privilege_exec",
             deescalate="end",

--- a/tests/unit/ruckus/fastiron/test_ruckus_fastiron.py
+++ b/tests/unit/ruckus/fastiron/test_ruckus_fastiron.py
@@ -24,6 +24,10 @@ from scrapli_community.ruckus.fastiron.ruckus_fastiron import DEFAULT_PRIVILEGE_
         ("privilege_exec", "SSH@ICX7150-24-Switch#"),
         ("configuration", "SSH@ICX7150-24-Switch(config)#"),
         ("configuration", "SSH@ICX7150-24-Switch(config-if-e1000-1/1/1)#"),
+        ("exec", "SSH@ICX7150-24-Switch(DEV)>"),
+        ("privilege_exec", "SSH@ICX7150-24-Switch(DEV)#"),
+        ("configuration", "SSH@ICX7150-24-Switch(DEV)(config)#"),
+        ("configuration", "SSH@ICX7150-24-Switch(DEV)(config-if-e1000-1/1/1)#"),
     ],
     ids=[
         "base_prompt_with_space_exec",
@@ -42,6 +46,10 @@ from scrapli_community.ruckus.fastiron.ruckus_fastiron import DEFAULT_PRIVILEGE_
         "ssh_prompt_privilege_exec",
         "ssh_prompt_configuration",
         "ssh_prompt_configuration_interface",
+        "ssh_prompt_exec_with_parentheses",
+        "ssh_prompt_privilege_exec_with_parentheses",
+        "ssh_prompt_with_parentheses_configuration",
+        "ssh_prompt_with_parentheses_configuration_interface",
     ],
 )
 def test_default_prompt_patterns(priv_pattern):


### PR DESCRIPTION
# Description

I'm submitting this change due to equipment found in the field that has parentheses in the hostname. Interestingly, the exec context already supported this, but it was missing from the privilege exec and config contexts. Unit tests have been updated to ensure the behavior is correct. I would not expect this to be a breaking change.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

After making this change I was able to communicate with the switches that were previously having the issue, as well as all previous equipment.


# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
