### PR TITLE
fix: aos-cx default_async_on_close command

### DIFF
--- a/scrapli_community/aruba/aoscx/async_driver.py
+++ b/scrapli_community/aruba/aoscx/async_driver.py
@@ -36,5 +36,5 @@ async def default_async_on_close(conn: AsyncNetworkDriver) -> None:
     # write exit directly to the transport as channel would fail to find the prompt after sending
     # the exit command!
     await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
-    conn.channel.write(channel_input="end")
+    conn.channel.write(channel_input="exit")
     conn.channel.send_return()


### PR DESCRIPTION
# Description
Fixed Aruba AOS-CX async driver. Related to [GH issue](https://github.com/scrapli/scrapli_community/issues/193)

## Type of change
Edited the close command from `end` to `exit`.


# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
